### PR TITLE
fix: update git credential configuration for providers

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -131,9 +131,11 @@
   path = ~/Source/Jeppesen/.gitconfig
 
 [credential]
-        helper = /usr/local/share/gcm-core/git-credential-manager
+  helper = /usr/local/share/gcm-core/git-credential-manager
 [credential "https://dev.azure.com"]
-        useHttpPath = true
+  useHttpPath = true
+[credential "https://gitlab-ext.digitalaviationservices.com"]
+  provider = generic
 {{- else }}
 [url "ssh://git@github.com/"]
   insteadOf = https://github.com/


### PR DESCRIPTION
Align the credential helper settings for consistency and add a new  credential provider for GitLab. Adjust the indentation for better  readability and understanding of the configuration structure.