### PR TITLE
feat: add GitButler commit workflow integration for Claude Code

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -1,0 +1,82 @@
+- Always follow the conventional commits format when commiting
+- always git add all files before running pre-commit
+- always unzip files to a temporary directory
+- always run go generate ./... when changing a graphql schema
+- if current branch is gitbutler/workspace, use but cli tool to create new feature branches, assign changes to branches (but rub)
+  and commiting (but commit)
+- it's always `but branch new` and not `bu branch create`
+- always name goose migrations with a numeric prefix with current date and time following the YYYYMMDDHHmmss format
+- Always add all files to git before running pre-commit since it stashes all unstaged files when running
+- I use GNU versions of rm and cp which ask for confirmation on replace and remove.
+- always use the latest versions of dependencies and docker images
+- We don't use docker buildx but build-tools
+- Always add unit tests when making changes, if possible
+
+## GitButler Workflow (when on gitbutler/workspace branch)
+
+When the current branch is `gitbutler/workspace`, use the `but` CLI instead of git.
+
+### Pre-Commit Analysis Workflow
+
+1. **Gather workspace state** (run both in parallel):
+   - `but status --json` - Get structured changes with CLI IDs
+   - `but branch list --json` - Get existing branches
+
+2. **Analyze change content** (sample diffs to understand patterns):
+   - Run `git diff HEAD -- <file>` on a few representative files
+   - Identify common change patterns across the repository
+   - Look for semantic themes (migrations, rotations, config updates)
+
+3. **Group changes by content pattern**, not just location:
+   - Example: "ProtonPass ID -> name migration (18 files)" - all files changing from ID-based to name-based ProtonPass references
+   - Example: "SSH key updates (4 files)" - all SSH key related changes
+   - Example: "Envrc cleanup (3 files)" - environment configuration standardization
+   - Secondary grouping by directory if changes are unrelated
+
+4. **Present change groups to user** with suggested branch names:
+   - Example: "ProtonPass name migration (18 files): `protonpass-name-migration`"
+   - Example: "Brewfile updates (1 file): `brewfile-update`"
+   - Identify existing branches that match the change type
+
+5. **Ask user for confirmation** on:
+   - How to group the changes (accept suggestions or regroup)
+   - Branch names (suggest but allow override)
+   - Assignment of changes to existing vs new branches
+
+### Commit Workflow
+
+1. **Create branches** if needed: `but branch new <name>`
+2. **Assign changes using CLI IDs** (NOT file paths):
+   - Single file: `but rub <cliId> <branch>` (e.g., `but rub g0 goodfeed-infra`)
+   - All unassigned: `but rub 00 <branch>` (when all changes go to one branch)
+3. **Commit to branch**: `but commit --only -m "message" <branch>`
+   - **IMPORTANT**: Always use `--only` flag to commit only the assigned files
+   - Without `--only`, all staged files will be committed regardless of branch assignment
+4. Follow conventional commits format
+5. Add `Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>` line
+
+### Key Commands Reference
+
+| Command | Purpose |
+|---------|---------|
+| `but status --json` | Get workspace state with CLI IDs |
+| `but branch list --json` | Get existing branches |
+| `but branch new <name>` | Create new branch |
+| `but rub <cliId> <branch>` | Assign single change (by CLI ID) to branch |
+| `but rub 00 <branch>` | Assign ALL unassigned changes to branch |
+| `but commit --only -m "msg" <branch>` | Commit only assigned files to branch |
+| `but commit -c --only -m "msg"` | Create new branch and commit assigned files |
+
+### CLI ID Format
+
+CLI IDs from `but status` are short codes like `g0`, `h0`, `i1`, etc.
+- First character: letter (a-z)
+- Second character: digit (0-9)
+- Special: `00` refers to ALL unassigned changes
+- Use these IDs in `but rub`, NOT file paths
+
+### Optimization: Bulk Assignment
+
+When all unassigned changes should go to a single branch:
+- Use `but rub 00 <branch>` to assign everything at once
+- This is faster than assigning files individually

--- a/private_dot_claude/hooks/executable_gitbutler-commit-hook.py
+++ b/private_dot_claude/hooks/executable_gitbutler-commit-hook.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook that intercepts git commands when on gitbutler/workspace branch
+and replaces them with equivalent 'but' CLI commands.
+"""
+import json
+import sys
+import subprocess
+
+
+def get_current_branch():
+    try:
+        return subprocess.check_output(
+            ["git", "branch", "--show-current"],
+            text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    except Exception:
+        return None
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    # Only intercept Bash tool with git commands
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    # Check if on gitbutler/workspace branch
+    current_branch = get_current_branch()
+    if current_branch != "gitbutler/workspace":
+        sys.exit(0)
+
+    modified_command = None
+
+    # Map git commands to but equivalents
+    if command.startswith("git commit"):
+        modified_command = command.replace("git commit", "but commit", 1)
+    elif command.startswith("git add") and "&&" in command and "git commit" in command:
+        # Handle "git add . && git commit" patterns
+        modified_command = command.replace("git commit", "but commit")
+    elif command.startswith("git status"):
+        modified_command = command.replace("git status", "but status", 1)
+
+    if modified_command:
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+                "permissionDecisionReason": "On gitbutler/workspace: using 'but' CLI",
+                "updatedInput": {"command": modified_command}
+            }
+        }
+        print(json.dumps(output))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": []
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/gitbutler-commit-hook.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add chezmoi-managed hook and instructions that:
- Intercept git commit/status commands when on gitbutler/workspace
- Replace them with equivalent 'but' CLI commands
- Provide guided workflow for analyzing and grouping changes

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>