### PR TITLE
feat(intersolia): add GitHub token tfvars template

### DIFF
--- a/Source/CustomerProjects/Intersolia/github-repos/default.auto.tfvars.tmpl
+++ b/Source/CustomerProjects/Intersolia/github-repos/default.auto.tfvars.tmpl
@@ -1,0 +1,3 @@
+{{- $item := protonPassJSON "pass://Personal/.auths" -}}
+{{- $note := $item.item.content.note -}}
+gh_token = {{ regexFind "IntersoliaInfraGithubToken:[^\n]*" $note | trimPrefix "IntersoliaInfraGithubToken:" | quote }}


### PR DESCRIPTION
Adds default.auto.tfvars.tmpl that retrieves the Intersolia infrastructure
GitHub token from ProtonPass.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>