### PR TITLE
feat(shell): add k8s-rds-tunnel function for RDS port forwarding

### DIFF
--- a/Source/CustomerProjects/GoodFeed/dot_envrc.tmpl
+++ b/Source/CustomerProjects/GoodFeed/dot_envrc.tmpl
@@ -6,5 +6,6 @@ export PATH=${PATH}:${PWD}/.bin
 export AWS_SSO_CONFIG=${PWD}/.aws-sso/config
 export AWS_CONFIG_FILE=${PWD}/.aws/config
 export KUBECONFIG=$( IFS=:; set -- ${PWD}/.kube/kind*.yaml ${PWD}/.kube/*.yaml; echo "$*" )
+export K8S_RDS_CONFIG=${PWD}/.kube/rds_config
 export BUILDKITE_API_TOKEN={{ regexFind "GoodfeedBuildkiteApiToken:[^\n]*" $note | trimPrefix "GoodfeedBuildkiteApiToken:" -}}
 export GITHUB_TOKEN={{ regexFind "GoodfeedGithubToken:[^\n]*" $note | trimPrefix "GoodfeedGithubToken:" }}

--- a/Source/CustomerProjects/GoodFeed/dot_kube/rds_config
+++ b/Source/CustomerProjects/GoodFeed/dot_kube/rds_config
@@ -1,0 +1,6 @@
+# k8s-rds-tunnel configuration
+# Format: cluster_name rds_host region [port]
+# Port defaults to 5432 if omitted
+
+k8s.staging.goodfeed.io backend.cluster-cnwdhsmgzjzz.eu-west-1.rds.amazonaws.com eu-west-1
+k8s.goodfeed.io backend.cluster-c3xiiwbnbw86.eu-west-1.rds.amazonaws.com eu-west-1

--- a/Source/CustomerProjects/Intersolia/dot_envrc.tmpl
+++ b/Source/CustomerProjects/Intersolia/dot_envrc.tmpl
@@ -6,6 +6,7 @@ layout pyenv 3.14.0
 
 export PATH=${PATH}:${PWD}/.bin
 export KUBECONFIG=$( IFS=:; set -- ${PWD}/.kube/kind*.yaml ${PWD}/.kube/*.yaml; echo "$*" )
+export K8S_RDS_CONFIG=${PWD}/.kube/rds_config
 
 export AWS_SSO_CONFIG=${PWD}/.aws-sso/config
 export AWS_CONFIG_FILE=${PWD}/.aws/config

--- a/Source/CustomerProjects/Intersolia/dot_kube/rds_config
+++ b/Source/CustomerProjects/Intersolia/dot_kube/rds_config
@@ -1,0 +1,7 @@
+# k8s-rds-tunnel configuration
+# Format: cluster_name rds_host region [port]
+# Port defaults to 5432 if omitted
+
+k8s.platform.intersolia.io platform.cluster-cpa4kgoogeu5.eu-north-1.rds.amazonaws.com eu-north-1
+k8s.intersolia.io shared.cluster-cb8qycm0qiz7.eu-north-1.rds.amazonaws.com eu-north-1
+k8s.dev.intersolia.io shared.cluster-chu6gwqekcof.eu-north-1.rds.amazonaws.com eu-north-1

--- a/Source/dot_envrc.tmpl
+++ b/Source/dot_envrc.tmpl
@@ -11,5 +11,6 @@ export NGROK_TOKEN={{ regexFind "token:[^\n]*" $ngrok | trimPrefix "token:" }}
 export NGROK_REGION=eu
 export NGROK_URL=https://usd.eu.ngrok.io
 export KUBECONFIG=$( IFS=:; set -- ${PWD}/.kube/kind*.yaml ${PWD}/.kube/*.yaml; echo "$*" )
+export K8S_RDS_CONFIG=${PWD}/.kube/rds_config
 #export DOCKER_HOST=unix:///${HOME}/.docker/run/docker.sock
 PATH_add /opt/homebrew/opt/ruby/bin

--- a/Source/dot_kube/rds_config
+++ b/Source/dot_kube/rds_config
@@ -1,0 +1,5 @@
+# k8s-rds-tunnel configuration
+# Format: cluster_name rds_host region [port]
+# Port defaults to 5432 if omitted
+
+k8s.unbound.se prod-psql.csmhb6o5r4v7.eu-west-1.rds.amazonaws.com eu-west-1


### PR DESCRIPTION
## Summary
- Add `k8s-rds-tunnel` function for port forwarding to RDS via AWS SSM through k8s nodes
- Supports `-p/--port` flag for custom local port (default: 35432)
- Tab completion for cluster names and flags
- Add RDS tunnel configs for GoodFeed, Intersolia, and Unbound projects

## Usage
```bash
k8s-rds-tunnel k8s.unbound.se
k8s-rds-tunnel -p 5433 k8s.staging.goodfeed.io
```

🤖 Generated with [Claude Code](https://claude.ai/code)