### PR TITLE
docs: update GitButler instructions and add new shell functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,8 @@ Defined in `dot_functions`:
 - `bup` - Safely update brew packages by validating Brewfile first
 - `ecr` - Login to AWS ECR
 - `reload` - Reload zsh configuration
+- `but-pull-all` - Update all GitButler projects to latest remote state (supports `-f/--force` and `-t/--timeout`)
+- `k8s-rds-tunnel` - Port forward to RDS via AWS SSM through k8s node (uses `K8S_RDS_CONFIG`)
 
 Git repository management aliases (from `dot_aliases`):
 - `updrepo` - Update all git repos in subdirectories

--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -18,6 +18,7 @@ When the current branch is `gitbutler/workspace`, use the `but` CLI instead of g
 
 - **NEVER use `git push`** when on the `gitbutler/workspace` branch. Use `but push <branch>` instead.
 - **Create PRs using `but pr new <branch>`** when the remote is GitHub.
+  - In non-interactive mode, must use `-m "title\n\nbody"`, `-t` (use commit message), or `-F <file>`
 
 ### Pre-Commit Analysis Workflow
 
@@ -76,7 +77,8 @@ When the current branch is `gitbutler/workspace`, use the `but` CLI instead of g
 | `but reword <commit-id> -m "msg"` | Edit a commit message |
 | `but reword <branch-id> -m "name"` | Rename a branch |
 | `but push <branch>` | Push branch to remote (use instead of `git push`) |
-| `but pr new <branch>` | Create a PR on GitHub for the given branch |
+| `but pr new -m "title\n\nbody" <branch>` | Create PR with custom title and body |
+| `but pr new -t <branch>` | Create PR using commit message as default content |
 | `but absorb` | Amend uncommitted changes into the appropriate existing commits |
 | `but absorb <cliId>` | Absorb a specific uncommitted file into its matching commit |
 | `but absorb <branch>` | Absorb all changes staged to a specific branch |


### PR DESCRIPTION
- Add but pr new flags (-m, -t, -F) for non-interactive mode
- Add but-pull-all and k8s-rds-tunnel to shell functions list
- Remove duplicate GitButler workflow from repo CLAUDE.md

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>