### PR TITLE
fix(shell): fix PATH destruction in but-pull-all and improve shell robustness

### DIFF
--- a/dot_functions
+++ b/dot_functions
@@ -95,6 +95,12 @@ but-pull-all() {
     local timeout_secs=30
     local filter=""
     local projects_file="$HOME/Library/Application Support/com.gitbutler.app/projects.json"
+    local but_cmd
+    but_cmd=$(command -v but)
+    if [[ -z "$but_cmd" ]]; then
+        echo "but command not found"
+        return 1
+    fi
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -121,18 +127,23 @@ but-pull-all() {
 
     local matched=0
 
-    for path in $(jq -r '.[].path' "$projects_file"); do
-        local name=$(basename "$path")
+    for project_path in $(jq -r '.[].path' "$projects_file"); do
+        local name=$(basename "$project_path")
 
         # Skip if filter provided and doesn't match
         if [[ -n "$filter" ]] && [[ "$name" != *"$filter"* ]]; then
             continue
         fi
 
-        if [[ -d "$path/.git/gitbutler" ]]; then
+        if [[ ! -d "$project_path" ]]; then
+            echo "$name: \033[33mpath not found, skipping\033[0m"
+            continue
+        fi
+
+        if [[ -d "$project_path/.git/gitbutler" ]]; then
             ((matched++))
             # Check status first
-            local check_output=$(timeout $timeout_secs but -C "$path" pull --check 2>&1)
+            local check_output=$(timeout $timeout_secs "$but_cmd" -C "$project_path" pull --check 2>&1)
             local check_status=$?
 
             if [[ $check_status -eq 124 ]]; then
@@ -144,13 +155,13 @@ but-pull-all() {
                 if [[ $force -eq 1 ]]; then
                     echo "$name: \033[33mcleaning broken refs...\033[0m"
                     # Find all broken refs from git branch warnings
-                    for ref in $(git -C "$path" branch 2>&1 | grep "warning: ignoring broken ref" | sed 's/.*refs\/heads\//refs\/heads\//'); do
+                    for ref in $(git -C "$project_path" branch 2>&1 | grep "warning: ignoring broken ref" | sed 's/.*refs\/heads\//refs\/heads\//'); do
                         echo "  removing $ref"
-                        git -C "$path" update-ref -d "$ref" 2>/dev/null
+                        git -C "$project_path" update-ref -d "$ref" 2>/dev/null
                     done
-                    git -C "$path" fetch --prune origin 2>/dev/null
+                    git -C "$project_path" fetch --prune origin 2>/dev/null
                     # Retry pull
-                    timeout $timeout_secs but -C "$path" pull
+                    timeout $timeout_secs "$but_cmd" -C "$project_path" pull
                     if [[ $? -eq 124 ]]; then
                         echo "\033[31m  timed out after ${timeout_secs}s\033[0m"
                     fi
@@ -161,7 +172,7 @@ but-pull-all() {
             else
                 # Has changes or errors - run with full output
                 echo "$name:"
-                timeout $timeout_secs but -C "$path" pull
+                timeout $timeout_secs "$but_cmd" -C "$project_path" pull
                 if [[ $? -eq 124 ]]; then
                     echo "\033[31m  timed out after ${timeout_secs}s\033[0m"
                 fi

--- a/dot_paths
+++ b/dot_paths
@@ -1,3 +1,5 @@
+prepend_path /opt/homebrew/bin
+prepend_path /opt/homebrew/sbin
 prepend_path /opt/homebrew/opt/grep/libexec/gnubin
 prepend_path /opt/homebrew/opt/gnu-getopt/bin
 prepend_path /opt/homebrew/opt/gnu-sed/libexec/gnubin

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -11,7 +11,7 @@ done
 
 function powerline_precmd() {
     ZLE_RPROMPT_INDENT=-1
-    eval "$($(go env GOPATH)/bin/powerline-go -error $? -shell zsh -eval -cwd-max-depth 4 -git-mode compact -modules ssh,cwd,exit -modules-right git,hg,aws,kube)"
+    eval "$($HOME/go/bin/powerline-go -error $? -shell zsh -eval -cwd-max-depth 4 -git-mode compact -modules ssh,cwd,exit -modules-right git,hg,aws,kube)"
 }
 
 function install_powerline_precmd() {


### PR DESCRIPTION
## Summary
- **Fix `but-pull-all` destroying PATH**: The loop variable `path` is a special zsh variable tied to `PATH`. Renamed to `project_path` to prevent PATH from being overwritten on every iteration.
- **Fix powerline prompt errors**: Replace `$(go env GOPATH)/bin/powerline-go` with `$HOME/go/bin/powerline-go` so the prompt doesn't depend on `go` being in PATH.
- **Fix `reload` breaking shell**: Add `/opt/homebrew/bin` to `dot_paths` so `reload` (which re-sources `.zshrc` without `.zprofile`) can find homebrew binaries like `direnv`.
- **Resolve `but` path for timeout**: Use `command -v but` upfront so `gtimeout` receives an absolute path.
- **Skip missing project directories** gracefully instead of erroring.

## Test plan
- [ ] Open new terminal, run `but-pull-all` — should list project statuses without errors
- [ ] Run `but-pull-all <filter>` — should filter correctly
- [ ] Run `reload` — should not error on direnv or other homebrew commands
- [ ] Verify `ls`, `git`, etc. still work after `but-pull-all` completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)