### PR TITLE
feat(tmux): add Claude Code notification hooks for tmux

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -80,7 +80,8 @@ set-option -g visual-activity off
 set-option -g visual-bell off
 set-option -g visual-silence off
 set-window-option -g monitor-activity off
-set-option -g bell-action none
+set-window-option -g monitor-bell on
+set-option -g bell-action other
 
 # The modes {
 setw -g clock-mode-colour colour135

--- a/private_dot_claude/hooks/executable_tmux-notify.sh
+++ b/private_dot_claude/hooks/executable_tmux-notify.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Claude Code hook: send tmux notifications on Stop and Notification events
+# Triggers a bell so monitor-bell highlights the window in the status bar
+
+# Only notify if inside a tmux session
+[ -z "$TMUX" ] && exit 0
+
+event=$(cat | jq -r '.hook_event_name // empty')
+
+case "$event" in
+    Stop)
+        tmux display-message "Claude finished responding"
+        printf '\a'
+        ;;
+    Notification)
+        tmux display-message "Claude is waiting for input"
+        printf '\a'
+        ;;
+esac
+
+exit 0

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
   "permissions": {
     "allow": []
   },
@@ -11,6 +14,31 @@
             "type": "command",
             "command": "python3 ~/.claude/hooks/gitbutler-commit-hook.py",
             "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/tmux-notify.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/tmux-notify.sh",
+            "timeout": 5,
+            "async": true
           }
         ]
       }


### PR DESCRIPTION
Add hooks that notify via tmux display-message and bell when:
- Claude finishes responding (Stop event)
- Claude is waiting for user input (Notification/permission_prompt)

Enable monitor-bell in tmux config so the window gets flagged in the
status bar when Claude needs attention from another pane.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>