### PR TITLE
feat(but-pull-all): support filtering by path

### DIFF
--- a/dot_completions
+++ b/dot_completions
@@ -115,7 +115,7 @@ __but_pull_all_complete() {
     '*:project:->projects'
 
   if [[ $state == projects ]] && [[ -f "$projects_file" ]]; then
-    local projects=($(jq -r '.[].path' "$projects_file" 2>/dev/null | xargs -I{} basename {} | sort -u))
+    local projects=($(jq -r '.[].path' "$projects_file" 2>/dev/null | while read -r p; do basename "$p"; dirname "$p" | xargs basename; done | sort -u))
     _describe 'project' projects
   fi
 }

--- a/dot_functions
+++ b/dot_functions
@@ -130,8 +130,8 @@ but-pull-all() {
     for project_path in $(jq -r '.[].path' "$projects_file"); do
         local name=$(basename "$project_path")
 
-        # Skip if filter provided and doesn't match
-        if [[ -n "$filter" ]] && [[ "$name" != *"$filter"* ]]; then
+        # Skip if filter provided and doesn't match name or path
+        if [[ -n "$filter" ]] && [[ "$name" != *"$filter"* ]] && [[ "$project_path" != *"$filter"* ]]; then
             continue
         fi
 


### PR DESCRIPTION
## Summary
- `but-pull-all` filter now matches against the full project path in addition to the project name
- This allows filtering by parent directory (e.g., `but-pull-all NordicLight` to update all NordicLight repos)
- Tab completion updated to also suggest parent directory names

## Test plan
- [ ] Run `but-pull-all NordicLight` and verify it matches all projects under that directory
- [ ] Run `but-pull-all <project-name>` and verify existing name-based filtering still works
- [ ] Verify tab completion offers both project names and parent directory names

🤖 Generated with [Claude Code](https://claude.com/claude-code)