### PR TITLE
docs: add instruction to cd into repo root before but commands

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -17,6 +17,7 @@
 
 When the current branch is `gitbutler/workspace`, use the `but` CLI instead of git.
 
+- **Always `cd` into the repository root** before running any `but` commands. The `but` CLI must be run from within the git working tree (or use `-C <path>`).
 - **NEVER use `git push`** when on the `gitbutler/workspace` branch. Use `but push <branch>` instead.
 - **Create PRs using `but pr new <branch>`** when the remote is GitHub.
   - In non-interactive mode, must use `-m "title\n\nbody"`, `-t` (use commit message), or `-F <file>`


### PR DESCRIPTION
## Summary
- Added rule to GitButler workflow instructions requiring `cd` into the repository root before running any `but` CLI commands
- The `but` CLI must be run from within the git working tree (or use `-C <path>`)

## Test plan
- [ ] Verify `~/.claude/CLAUDE.md` contains the new instruction after `chezmoi apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)