### PR TITLE
feat: add read-only gh api hook and allow read-only gh commands

### DIFF
--- a/private_dot_claude/hooks/executable_gh-api-readonly.sh
+++ b/private_dot_claude/hooks/executable_gh-api-readonly.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# PreToolUse hook: allow only read-only (GET) gh api calls.
+# Blocks POST, PUT, DELETE, PATCH and data-mutation flags.
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+# Only check gh api commands
+case "$command" in
+  *"gh api"*) ;;
+  *) exit 0 ;;
+esac
+
+# Block explicit write methods: -X POST, --method DELETE, etc.
+if echo "$command" | grep -qEi '(\s|^)-X\s*(POST|PUT|DELETE|PATCH)|\s--method\s+(POST|PUT|DELETE|PATCH)'; then
+  echo "Blocked: only read-only (GET) gh api calls are allowed" >&2
+  exit 2
+fi
+
+# Block data flags that imply mutation (-d, -f, --raw-field, --field, --input)
+if echo "$command" | grep -qE '\s(-d|--raw-field|-f|--field|--input)\s'; then
+  echo "Blocked: data flags (-d, -f, --input) imply a write operation" >&2
+  exit 2
+fi
+
+exit 0

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -3,7 +3,27 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "permissions": {
-    "allow": []
+    "allow": [
+      "Bash(gh api *)",
+      "Bash(gh repo view *)",
+      "Bash(gh repo list *)",
+      "Bash(gh issue view *)",
+      "Bash(gh issue list *)",
+      "Bash(gh issue status *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh pr checks *)",
+      "Bash(gh pr status *)",
+      "Bash(gh run list *)",
+      "Bash(gh run view *)",
+      "Bash(gh workflow list *)",
+      "Bash(gh workflow view *)",
+      "Bash(gh search *)",
+      "Bash(gh label list *)",
+      "Bash(gh release list *)",
+      "Bash(gh auth status *)"
+    ]
   },
   "hooks": {
     "PreToolUse": [
@@ -14,6 +34,11 @@
             "type": "command",
             "command": "python3 ~/.claude/hooks/gitbutler-commit-hook.py",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/gh-api-readonly.sh",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add PreToolUse hook that blocks write operations (POST/PUT/DELETE/PATCH) on `gh api` calls
- Allow read-only `gh` CLI commands (view, list, diff, status, checks, search) without prompting
- All managed via chezmoi (`private_dot_claude/`)

## Test plan
- [ ] Start new Claude Code session to pick up settings changes
- [ ] Verify `gh api /user` runs without prompting
- [ ] Verify `gh api -X POST ...` is blocked by hook
- [ ] Verify `gh pr list` runs without prompting

Generated with [Claude Code](https://claude.com/claude-code)