### PR TITLE
feat: add Gitea CLI tool (tea) to Brewfile

### DIFF
--- a/dot_local/share/Brewfile.tmpl
+++ b/dot_local/share/Brewfile.tmpl
@@ -145,6 +145,7 @@ brew "socat"
 brew "ssh-copy-id", link: true
 brew "stern"
 brew "swagger-codegen"
+brew "tea"
 brew "telnet"
 brew "tig"
 brew "tmux"


### PR DESCRIPTION
## Summary
- Adds the `tea` Gitea CLI tool to the shared Brewfile

## Test plan
- [ ] Run `brew bundle --file ~/.local/share/Brewfile` and verify `tea` installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)