### PR TITLE
refactor: migrate ProtonPass templates to direct field access

### DIFF
--- a/Source/CustomerProjects/GoodFeed/dot_envrc.tmpl
+++ b/Source/CustomerProjects/GoodFeed/dot_envrc.tmpl
@@ -1,5 +1,3 @@
-{{- $item := protonPassJSON "pass://Personal/.auths" -}}
-{{- $note := $item.item.content.note -}}
 source_up .envrc
 
 export PATH=${PATH}:${PWD}/.bin
@@ -7,5 +5,5 @@ export AWS_SSO_CONFIG=${PWD}/.aws-sso/config
 export AWS_CONFIG_FILE=${PWD}/.aws/config
 export KUBECONFIG=$( IFS=:; set -- ${PWD}/.kube/kind*.yaml ${PWD}/.kube/*.yaml; echo "$*" )
 export K8S_RDS_CONFIG=${PWD}/.kube/rds_config
-export BUILDKITE_API_TOKEN={{ regexFind "GoodfeedBuildkiteApiToken:[^\n]*" $note | trimPrefix "GoodfeedBuildkiteApiToken:" -}}
-export GITHUB_TOKEN={{ regexFind "GoodfeedGithubToken:[^\n]*" $note | trimPrefix "GoodfeedGithubToken:" }}
+export BUILDKITE_API_TOKEN={{ protonPass "pass://Personal/.auths/GoodfeedBuildkiteApiToken" | trim }}
+export GITHUB_TOKEN={{ protonPass "pass://Personal/.auths/GoodfeedGithubToken" | trim }}

--- a/Source/CustomerProjects/Intersolia/dot_envrc.tmpl
+++ b/Source/CustomerProjects/Intersolia/dot_envrc.tmpl
@@ -1,5 +1,3 @@
-{{- $item := protonPassJSON "pass://Personal/Intersolia" -}}
-{{- $note := $item.item.content.note -}}
 source_up .envrc
 
 layout pyenv 3.14.0
@@ -7,12 +5,15 @@ layout pyenv 3.14.0
 export PATH=${PATH}:${PWD}/.bin
 export KUBECONFIG=$( IFS=:; set -- ${PWD}/.kube/kind*.yaml ${PWD}/.kube/*.yaml; echo "$*" )
 export K8S_RDS_CONFIG=${PWD}/.kube/rds_config
-export STATEGRAPH_API_KEY={{ regexFind "StategraphApiKey:[^\n]*" $note | trimPrefix "StategraphApiKey:" }}
+export STATEGRAPH_API_BASE=https://stategraph.platform.intersolia.io
+export STATEGRAPH_API_KEY={{ protonPass "pass://Personal/Intersolia/StategraphApiKey" | trim }}
+export TF_HTTP_USERNAME=session
+export TF_HTTP_PASSWORD="$STATEGRAPH_API_KEY"
 
 export AWS_SSO_CONFIG=${PWD}/.aws-sso/config
 export AWS_CONFIG_FILE=${PWD}/.aws/config
 
-export GITHUB_TOKEN={{ regexFind "GithubToken:[^\n]*" $note | trimPrefix "GithubToken:" }}
+export GITHUB_TOKEN={{ protonPass "pass://Personal/Intersolia/GithubToken" | trim }}
 
 export AUTH_JWKS_URI=http://keycloak.localhost/realms/intersolia/protocol/openid-connect/certs
 export AUTH_ISSUER=http://keycloak.localhost/realms/intersolia

--- a/Source/CustomerProjects/Intersolia/github-repos/default.auto.tfvars.tmpl
+++ b/Source/CustomerProjects/Intersolia/github-repos/default.auto.tfvars.tmpl
@@ -1,3 +1,1 @@
-{{- $item := protonPassJSON "pass://Personal/Intersolia" -}}
-{{- $note := $item.item.content.note -}}
-gh_token = {{ regexFind "InfraGithubToken:[^\n]*" $note | trimPrefix "InfraGithubToken:" | quote }}
+gh_token = {{ protonPass "pass://Personal/Intersolia/InfraGithubToken" | trim | quote }}

--- a/Source/CustomerProjects/Paidit/infra/default.auto.tfvars.tmpl
+++ b/Source/CustomerProjects/Paidit/infra/default.auto.tfvars.tmpl
@@ -1,34 +1,26 @@
 {{- $cloudamqp := (protonPassJSON "pass://PaidIT shared/cloudamqp_api_key").item.content.note -}}
-{{- $mongo := (protonPassJSON "pass://PaidIT shared/Mongo Atlas API Project").item.content.extra_fields -}}
 {{- $harbourProd := (protonPassJSON "pass://PaidIT shared/prod-harbour").item.content.note -}}
 {{- $harbourDemo := (protonPassJSON "pass://PaidIT shared/demo-harbour").item.content.note -}}
 {{- $harbourStage := (protonPassJSON "pass://PaidIT shared/stage-harbour").item.content.note -}}
 {{- $elks := (protonPassJSON "pass://PaidIT shared/46elks").item.content.content.Login -}}
-{{- $stripeProd := (protonPassJSON "pass://PaidIT shared/stripe_prod").item.content.extra_fields -}}
-{{- $stripeDev := (protonPassJSON "pass://PaidIT shared/stripe_dev").item.content.extra_fields -}}
 {{- $firestoreProd := (protonPassJSON "pass://PaidIT shared/prod-firestore").item.content.note -}}
 {{- $firestoreDemo := (protonPassJSON "pass://PaidIT shared/demo-firestore").item.content.note -}}
 {{- $firestoreStage := (protonPassJSON "pass://PaidIT shared/stage-firestore").item.content.note -}}
-{{- $swedbankProd := (protonPassJSON "pass://PaidIT shared/prod-swedbank").item.content.note -}}
-{{- $swedbankDemo := (protonPassJSON "pass://PaidIT shared/demo-swedbank").item.content.note -}}
-{{- $swedbankStage := (protonPassJSON "pass://PaidIT shared/stage-swedbank").item.content.note -}}
 {{- $infrasecProd := (protonPassJSON "pass://PaidIT shared/prod-infrasec").item.content -}}
 {{- $infrasecDemo := (protonPassJSON "pass://PaidIT shared/demo-infrasec").item.content -}}
 {{- $infrasecStage := (protonPassJSON "pass://PaidIT shared/stage-infrasec").item.content -}}
-{{- $slackWebhook := (protonPassJSON "pass://PaidIT shared/slack_webhook_url").item.content.note -}}
 {{- $dockercfg := (protonPassJSON "pass://PaidIT shared/dockercfg").item.content.note -}}
-{{- $grafana := (protonPassJSON "pass://PaidIT shared/grafana-cloud").item.content.note -}}
 {{- $gitlabToken := (protonPassJSON "pass://PaidIT shared/gitlab_token").item.content.note -}}
 cloudamqp_customer_api_key = "{{ $cloudamqp -}}"
-mongodbatlas_private_key   = {{ (index $mongo 5).content.Hidden | trim | quote }}
-mongodbatlas_public_key    = {{ (index $mongo 4).content.Text | trim | quote }}
-slack_ops_url              = {{ regexFind "ops:[^\n]*" $slackWebhook | trimPrefix "ops:" | trim | quote }}
+mongodbatlas_private_key   = {{ protonPass "pass://PaidIT shared/Mongo Atlas API Project/privateKey" | trim | quote }}
+mongodbatlas_public_key    = {{ protonPass "pass://PaidIT shared/Mongo Atlas API Project/publicKey" | trim | quote }}
+slack_ops_url              = {{ protonPass "pass://PaidIT shared/slack_webhook_url/ops" | trim | quote }}
 docker_config              = <<EOT
 {{ $dockercfg }}
 EOT
-grafana_cloud_api_key      = {{ regexFind "grafanaApiKey:[^\n]*" $grafana | trimPrefix "grafanaApiKey:" | trim | quote }}
-loki_api_key               = {{ regexFind "lokiApiKey:[^\n]*" $grafana | trimPrefix "lokiApiKey:" | trim | quote }}
-prometheus_api_key         = {{ regexFind "prometheusApiKey:[^\n]*" $grafana | trimPrefix "prometheusApiKey:" | trim | quote }}
+grafana_cloud_api_key      = {{ protonPass "pass://PaidIT shared/grafana-cloud/grafanaApiKey" | trim | quote }}
+loki_api_key               = {{ protonPass "pass://PaidIT shared/grafana-cloud/lokiApiKey" | trim | quote }}
+prometheus_api_key         = {{ protonPass "pass://PaidIT shared/grafana-cloud/prometheusApiKey" | trim | quote }}
 harbour_secret_prod = {
   API_KEY = "{{ $harbourProd -}}"
 }
@@ -40,14 +32,14 @@ harbour_secret_stage = {
 }
 fortysixelks_password = {{ $elks.password | trim | quote }}
 stripe_prod = {
-  STRIPE_PUBLIC_KEY = {{ (index $stripeProd 0).content.Text | trim | quote }}
-  STRIPE_SECRET_KEY = {{ (index $stripeProd 1).content.Text | trim | quote }}
-  WEBHOOK_SECRET    = {{ (index $stripeProd 2).content.Text | trim | quote }}
+  STRIPE_PUBLIC_KEY = {{ protonPass "pass://PaidIT shared/stripe_prod/clientId" | trim | quote }}
+  STRIPE_SECRET_KEY = {{ protonPass "pass://PaidIT shared/stripe_prod/secret" | trim | quote }}
+  WEBHOOK_SECRET    = {{ protonPass "pass://PaidIT shared/stripe_prod/webhookSecret" | trim | quote }}
 }
 stripe_dev = {
-  STRIPE_PUBLIC_KEY = {{ (index $stripeDev 0).content.Text | trim | quote }}
-  STRIPE_SECRET_KEY = {{ (index $stripeDev 1).content.Text | trim | quote }}
-  WEBHOOK_SECRET    = {{ (index $stripeDev 2).content.Text | trim | quote }}
+  STRIPE_PUBLIC_KEY = {{ protonPass "pass://PaidIT shared/stripe_dev/clientId" | trim | quote }}
+  STRIPE_SECRET_KEY = {{ protonPass "pass://PaidIT shared/stripe_dev/secret" | trim | quote }}
+  WEBHOOK_SECRET    = {{ protonPass "pass://PaidIT shared/stripe_dev/webhookSecret" | trim | quote }}
 }
 firestore_prod  = <<EOT
 {{ $firestoreProd -}}
@@ -60,30 +52,30 @@ firestore_stage = <<EOT
 EOT
 swedbank_cert_prod = {
   pem   = <<EOT
-{{ regexFind "publicKey:[^\n]*" $swedbankProd | trimPrefix "publicKey:" | trim | replace "^^" "\n" -}}
+{{ protonPass "pass://PaidIT shared/prod-swedbank/publicKey" | trim | replace "^^" "\n" -}}
 EOT
   key   = <<EOT
-{{ regexFind "privateKey:[^\n]*" $swedbankProd | trimPrefix "privateKey:" | trim | replace "^^" "\n" -}}
+{{ protonPass "pass://PaidIT shared/prod-swedbank/privateKey" | trim | replace "^^" "\n" -}}
 EOT
-  alias = {{ regexFind "hostname:[^\n]*" $swedbankProd | trimPrefix "hostname:" | trim | quote }}
+  alias = {{ protonPass "pass://PaidIT shared/prod-swedbank/hostname" | trim | quote }}
 }
 swedbank_cert_demo = {
   pem   = <<EOT
-{{ regexFind "publicKey:[^\n]*" $swedbankDemo | trimPrefix "publicKey:" | trim | replace "^^" "\n" -}}
+{{ protonPass "pass://PaidIT shared/demo-swedbank/publicKey" | trim | replace "^^" "\n" -}}
 EOT
   key   = <<EOT
-{{ regexFind "privateKey:[^\n]*" $swedbankDemo | trimPrefix "privateKey:" | trim | replace "^^" "\n" -}}
+{{ protonPass "pass://PaidIT shared/demo-swedbank/privateKey" | trim | replace "^^" "\n" -}}
 EOT
-  alias = {{ regexFind "hostname:[^\n]*" $swedbankDemo | trimPrefix "hostname:" | trim | quote }}
+  alias = {{ protonPass "pass://PaidIT shared/demo-swedbank/hostname" | trim | quote }}
 }
 swedbank_cert_stage = {
   pem   = <<EOT
-{{ regexFind "publicKey:[^\n]*" $swedbankStage | trimPrefix "publicKey:" | trim | replace "^^" "\n" -}}
+{{ protonPass "pass://PaidIT shared/stage-swedbank/publicKey" | trim | replace "^^" "\n" -}}
 EOT
   key   = <<EOT
-{{ regexFind "privateKey:[^\n]*" $swedbankStage | trimPrefix "privateKey:" | trim | replace "^^" "\n" -}}
+{{ protonPass "pass://PaidIT shared/stage-swedbank/privateKey" | trim | replace "^^" "\n" -}}
 EOT
-  alias = {{ regexFind "hostname:[^\n]*" $swedbankStage | trimPrefix "hostname:" | trim | quote }}
+  alias = {{ protonPass "pass://PaidIT shared/stage-swedbank/hostname" | trim | quote }}
 }
 infrasec_cert_prod = {
   ca         = <<EOT

--- a/Source/CustomerProjects/Sensapp/dot_envrc.tmpl
+++ b/Source/CustomerProjects/Sensapp/dot_envrc.tmpl
@@ -1,7 +1,6 @@
-{{- $azure := (protonPassJSON "pass://Sensapp shared/azure-credentials").item.content.note -}}
 source_up .envrc
 
 export PATH=${PWD}/.bin:${PATH}
 export KUBECONFIG=$( IFS=:; set -- ${PWD}/.kube/kind*.yaml ${PWD}/.kube/*.yaml; echo "$*" )
-export AZURE_TENANT_ID={{ regexFind "azureTenantId:[^\n]*" $azure | trimPrefix "azureTenantId:" }}
-export AZURE_CLIENT_ID={{ regexFind "azureClientId:[^\n]*" $azure | trimPrefix "azureClientId:" -}}
+export AZURE_TENANT_ID={{ protonPass "pass://Sensapp shared/azure-credentials/azureTenantId" | trim }}
+export AZURE_CLIENT_ID={{ protonPass "pass://Sensapp shared/azure-credentials/azureClientId" | trim -}}

--- a/Source/Infrastructure/infra/auth0/default.auto.tfvars.tmpl
+++ b/Source/Infrastructure/infra/auth0/default.auto.tfvars.tmpl
@@ -1,16 +1,13 @@
-{{- $auth0 := (protonPassJSON "pass://Unbound Infrastructure/auth0").item.content.note -}}
-{{- $google := (protonPassJSON "pass://Unbound Infrastructure/google").item.content.note -}}
-{{- $facebook := (protonPassJSON "pass://Unbound Infrastructure/facebook").item.content.note -}}
 auth0 = {
-  domain        = {{ regexFind "domain:[^\n]*" $auth0 | trimPrefix "domain:" | trim | quote }}
-  client_id     = {{ regexFind "clientId:[^\n]*" $auth0 | trimPrefix "clientId:" | trim | quote }}
-  client_secret = {{ regexFind "clientSecret:[^\n]*" $auth0 | trimPrefix "clientSecret:" | trim | quote }}
+  domain        = {{ protonPass "pass://Unbound Infrastructure/auth0/domain" | trim | quote }}
+  client_id     = {{ protonPass "pass://Unbound Infrastructure/auth0/clientId" | trim | quote }}
+  client_secret = {{ protonPass "pass://Unbound Infrastructure/auth0/clientSecret" | trim | quote }}
   google = {
-    client_id     = {{ regexFind "clientId:[^\n]*" $google | trimPrefix "clientId:" | trim | quote }}
-    client_secret = {{ regexFind "clientSecret:[^\n]*" $google | trimPrefix "clientSecret:" | trim | quote }}
+    client_id     = {{ protonPass "pass://Unbound Infrastructure/google/clientId" | trim | quote }}
+    client_secret = {{ protonPass "pass://Unbound Infrastructure/google/clientSecret" | trim | quote }}
   }
   facebook = {
-    client_id     = {{ regexFind "clientId:[^\n]*" $facebook | trimPrefix "clientId:" | trim | quote }}
-    client_secret = {{ regexFind "clientSecret:[^\n]*" $facebook | trimPrefix "clientSecret:" | trim | quote }}
+    client_id     = {{ protonPass "pass://Unbound Infrastructure/facebook/clientId" | trim | quote }}
+    client_secret = {{ protonPass "pass://Unbound Infrastructure/facebook/clientSecret" | trim | quote }}
   }
 }

--- a/Source/Infrastructure/infra/aws/default.auto.tfvars.tmpl
+++ b/Source/Infrastructure/infra/aws/default.auto.tfvars.tmpl
@@ -1,51 +1,46 @@
-{{- $slack := (protonPassJSON "pass://Unbound Infrastructure/slack").item.content.note -}}
 {{- $dockercfg := (protonPassJSON "pass://Unbound Infrastructure/dockercfg").item.content.note -}}
-{{- $auths := (protonPassJSON "pass://Personal/.auths").item.content.note -}}
-{{- $grafana := (protonPassJSON "pass://Unbound Infrastructure/grafana-cloud").item.content.note -}}
-{{- $gitea := (protonPassJSON "pass://Unbound Infrastructure/gitea").item.content.note -}}
-{{- $k8s := (protonPassJSON "pass://Unbound Infrastructure/k8s").item.content.note -}}
 slack = {
-  ops          = {{ regexFind "ops:[^\n]*" $slack | trimPrefix "ops:" | trim | quote }}
-  gitlab_ci    = {{ regexFind "gitlabCi:[^\n]*" $slack | trimPrefix "gitlabCi:" | trim | quote }}
-  dancefinder  = {{ regexFind "dancefinder:[^\n]*" $slack | trimPrefix "dancefinder:" | trim | quote }}
-  shiny        = {{ regexFind "shiny:[^\n]*" $slack | trimPrefix "shiny:" | trim | quote }}
-  hifi         = {{ regexFind "hifi:[^\n]*" $slack | trimPrefix "hifi:" | trim | quote }}
-  eventsourced = {{ regexFind "eventsourced:[^\n]*" $slack | trimPrefix "eventsourced:" | trim | quote }}
-  angus        = {{ regexFind "angus:[^\n]*" $slack | trimPrefix "angus:" | trim | quote }}
+  ops          = {{ protonPass "pass://Unbound Infrastructure/slack/ops" | trim | quote }}
+  gitlab_ci    = {{ protonPass "pass://Unbound Infrastructure/slack/gitlabCi" | trim | quote }}
+  dancefinder  = {{ protonPass "pass://Unbound Infrastructure/slack/dancefinder" | trim | quote }}
+  shiny        = {{ protonPass "pass://Unbound Infrastructure/slack/shiny" | trim | quote }}
+  hifi         = {{ protonPass "pass://Unbound Infrastructure/slack/hifi" | trim | quote }}
+  eventsourced = {{ protonPass "pass://Unbound Infrastructure/slack/eventsourced" | trim | quote }}
+  angus        = {{ protonPass "pass://Unbound Infrastructure/slack/angus" | trim | quote }}
 }
 docker_config                  = <<EOT
 {{ $dockercfg }}
 EOT
-gitlab_provider_token          = {{ regexFind "GitlabTerraformToken:[^\n]*" $auths | trimPrefix "GitlabTerraformToken:" | trim | quote }}
-grafana_cloud_api_key          = {{ regexFind "terraform:[^\n]*" $grafana | trimPrefix "terraform:" | trim | quote }}
-grafana_oncall_token           = {{ regexFind "terraformOnCall:[^\n]*" $grafana | trimPrefix "terraformOnCall:" | trim | quote }}
+gitlab_provider_token          = {{ protonPass "pass://Personal/.auths/GitlabTerraformToken" | trim | quote }}
+grafana_cloud_api_key          = {{ protonPass "pass://Unbound Infrastructure/grafana-cloud/terraform" | trim | quote }}
+grafana_oncall_token           = {{ protonPass "pass://Unbound Infrastructure/grafana-cloud/terraformOnCall" | trim | quote }}
 grafana_oncall_username        = "argoyle"
-gitea_admin_password           = {{ regexFind "AdminPassword:[^\n]*" $gitea | trimPrefix "AdminPassword:" | trim | quote }}
-gitea_db_password              = {{ regexFind "DbPassword:[^\n]*" $gitea | trimPrefix "DbPassword:" | trim | quote }}
-gitea_secret_key               = {{ regexFind "SecretKey:[^\n]*" $gitea | trimPrefix "SecretKey:" | trim | quote }}
-gitea_internal_token           = {{ regexFind "InternalToken:[^\n]*" $gitea | trimPrefix "InternalToken:" | trim | quote }}
-gitea_lfs_jwt_secret           = {{ regexFind "LfsJwtSecret:[^\n]*" $gitea | trimPrefix "LfsJwtSecret:" | trim | quote }}
-gitea_oauth2_jwt_secret        = {{ regexFind "OauthJwtSecret:[^\n]*" $gitea | trimPrefix "OauthJwtSecret:" | trim | quote }}
-gitea_runner_token             = {{ regexFind "RunnerToken:[^\n]*" $gitea | trimPrefix "RunnerToken:" | trim | quote }}
-gitea_runner_registry_token    = {{ regexFind "BuildtoolsToken:[^\n]*" $gitea | trimPrefix "BuildtoolsToken:" | trim | quote }}
-renovate_gitea_token           = {{ regexFind "RenovateToken:[^\n]*" $gitea | trimPrefix "RenovateToken:" | trim | quote }}
-gitea_admin_api_token          = {{ regexFind "AdminToken:[^\n]*" $gitea | trimPrefix "AdminToken:" | trim | quote }}
-gitea_release_token            = {{ regexFind "ReleaseToken:[^\n]*" $gitea | trimPrefix "ReleaseToken:" | trim | quote }}
+gitea_admin_password           = {{ protonPass "pass://Unbound Infrastructure/gitea/AdminPassword" | trim | quote }}
+gitea_db_password              = {{ protonPass "pass://Unbound Infrastructure/gitea/DbPassword" | trim | quote }}
+gitea_secret_key               = {{ protonPass "pass://Unbound Infrastructure/gitea/SecretKey" | trim | quote }}
+gitea_internal_token           = {{ protonPass "pass://Unbound Infrastructure/gitea/InternalToken" | trim | quote }}
+gitea_lfs_jwt_secret           = {{ protonPass "pass://Unbound Infrastructure/gitea/LfsJwtSecret" | trim | quote }}
+gitea_oauth2_jwt_secret        = {{ protonPass "pass://Unbound Infrastructure/gitea/OauthJwtSecret" | trim | quote }}
+gitea_runner_token             = {{ protonPass "pass://Unbound Infrastructure/gitea/RunnerToken" | trim | quote }}
+gitea_runner_registry_token    = {{ protonPass "pass://Unbound Infrastructure/gitea/BuildtoolsToken" | trim | quote }}
+renovate_gitea_token           = {{ protonPass "pass://Unbound Infrastructure/gitea/RenovateToken" | trim | quote }}
+gitea_admin_api_token          = {{ protonPass "pass://Unbound Infrastructure/gitea/AdminToken" | trim | quote }}
+gitea_release_token            = {{ protonPass "pass://Unbound Infrastructure/gitea/ReleaseToken" | trim | quote }}
 docker_hub_username            = "joakim@unbound.se"
-docker_hub_token               = {{ regexFind "DockerHubToken:[^\n]*" $k8s | trimPrefix "DockerHubToken:" | trim | quote }}
+docker_hub_token               = {{ protonPass "pass://Unbound Infrastructure/k8s/DockerHubToken" | trim | quote }}
 github_username                = "argoyle"
-github_token                   = {{ regexFind "GithubToken:[^\n]*" $k8s | trimPrefix "GithubToken:" | trim | quote }}
-gitea_registry_pull_token      = {{ regexFind "GiteaPullToken:[^\n]*" $gitea | trimPrefix "GiteaPullToken:" | trim | quote }}
-renovate_github_token          = {{ regexFind "RenovateGithubToken:[^\n]*" $auths | trimPrefix "RenovateGithubToken:" | trim | quote }}
+github_token                   = {{ protonPass "pass://Unbound Infrastructure/k8s/GithubToken" | trim | quote }}
+gitea_registry_pull_token      = {{ protonPass "pass://Unbound Infrastructure/gitea/GiteaPullToken" | trim | quote }}
+renovate_github_token          = {{ protonPass "pass://Personal/.auths/RenovateGithubToken" | trim | quote }}
 gitea_ssh_host_ed25519_key     = <<EOT
-{{ regexFind "SshHostKeyEDDSA:[^\n]*" $gitea | trimPrefix "SshHostKeyEDDSA:" | trim | b64dec -}}
+{{ protonPass "pass://Unbound Infrastructure/gitea/SshHostKeyEDDSA" | trim | b64dec -}}
 EOT
-gitea_ssh_host_ed25519_key_pub = {{ regexFind "SshHostKeyPubEDDSA:[^\n]*" $gitea | trimPrefix "SshHostKeyPubEDDSA:" | trim | quote }}
+gitea_ssh_host_ed25519_key_pub = {{ protonPass "pass://Unbound Infrastructure/gitea/SshHostKeyPubEDDSA" | trim | quote }}
 gitea_ssh_host_rsa_key         = <<EOT
-{{ regexFind "SshHostKeyRSA:[^\n]*" $gitea | trimPrefix "SshHostKeyRSA:" | trim | b64dec -}}
+{{ protonPass "pass://Unbound Infrastructure/gitea/SshHostKeyRSA" | trim | b64dec -}}
 EOT
-gitea_ssh_host_rsa_key_pub     = {{ regexFind "SshHostKeyPubRSA:[^\n]*" $gitea | trimPrefix "SshHostKeyPubRSA:" | trim | quote }}
+gitea_ssh_host_rsa_key_pub     = {{ protonPass "pass://Unbound Infrastructure/gitea/SshHostKeyPubRSA" | trim | quote }}
 gitea_ssh_host_ecdsa_key       = <<EOT
-{{ regexFind "SshHostKeyECDSA:[^\n]*" $gitea | trimPrefix "SshHostKeyECDSA:" | trim | b64dec -}}
+{{ protonPass "pass://Unbound Infrastructure/gitea/SshHostKeyECDSA" | trim | b64dec -}}
 EOT
-gitea_ssh_host_ecdsa_key_pub   = {{ regexFind "SshHostKeyPubECDSA:[^\n]*" $gitea | trimPrefix "SshHostKeyPubECDSA:" | trim | quote }}
+gitea_ssh_host_ecdsa_key_pub   = {{ protonPass "pass://Unbound Infrastructure/gitea/SshHostKeyPubECDSA" | trim | quote }}

--- a/Source/Infrastructure/infra/cloudamqp/default.auto.tfvars.tmpl
+++ b/Source/Infrastructure/infra/cloudamqp/default.auto.tfvars.tmpl
@@ -1,4 +1,3 @@
 {{- $cloudamqp := (protonPassJSON "pass://Unbound Infrastructure/cloudamqp_api_key").item.content.note -}}
-{{- $slack := (protonPassJSON "pass://Unbound Infrastructure/slack").item.content.note -}}
 cloudamqp_customer_api_key = "{{ $cloudamqp -}}"
-slack_webhook              = {{ regexFind "ops:[^\n]*" $slack | trimPrefix "ops:" | trim | quote }}
+slack_webhook              = {{ protonPass "pass://Unbound Infrastructure/slack/ops" | trim | quote }}

--- a/Source/Infrastructure/infra/gitea/default.auto.tfvars.tmpl
+++ b/Source/Infrastructure/infra/gitea/default.auto.tfvars.tmpl
@@ -1,15 +1,12 @@
-{{- $gitea := (protonPassJSON "pass://Unbound Infrastructure/gitea").item.content.note -}}
-{{- $auths := (protonPassJSON "pass://Personal/.auths").item.content.note -}}
-{{- $slack := (protonPassJSON "pass://Unbound Infrastructure/slack").item.content.note -}}
-gitea_token           = {{ regexFind "Terraform:[^\n]*" $gitea | trimPrefix "Terraform:" | trim | quote }}
-gitlab_token          = {{ regexFind "GitlabTerraformToken:[^\n]*" $auths | trimPrefix "GitlabTerraformToken:" | trim | quote }}
-anthropic_api_key     = {{ regexFind "AnthropicApiKey:[^\n]*" $gitea | trimPrefix "AnthropicApiKey:" | trim | quote }}
-gitea_actions_token   = {{ regexFind "GiteaActionsToken:[^\n]*" $gitea | trimPrefix "GiteaActionsToken:" | trim | quote }}
-slack_url             = {{ regexFind "gitea:[^\n]*" $slack | trimPrefix "gitea:" | trim | quote }}
-aws_access_key_id     = {{ regexFind "TerraformKey:[^\n]*" $gitea | trimPrefix "TerraformKey:" | trim | quote }}
-aws_secret_access_key = {{ regexFind "TerraformSecret:[^\n]*" $gitea | trimPrefix "TerraformSecret:" | trim | quote }}
-schemas_api_key       = {{ regexFind "SchemasApiKey:[^\n]*" $gitea | trimPrefix "SchemasApiKey:" | trim | quote }}
-acctest_token         = {{ regexFind "AcctestToken:[^\n]*" $gitea | trimPrefix "AcctestToken:" | trim | quote }}
+gitea_token           = {{ protonPass "pass://Unbound Infrastructure/gitea/Terraform" | trim | quote }}
+gitlab_token          = {{ protonPass "pass://Personal/.auths/GitlabTerraformToken" | trim | quote }}
+anthropic_api_key     = {{ protonPass "pass://Unbound Infrastructure/gitea/AnthropicApiKey" | trim | quote }}
+gitea_actions_token   = {{ protonPass "pass://Unbound Infrastructure/gitea/GiteaActionsToken" | trim | quote }}
+slack_url             = {{ protonPass "pass://Unbound Infrastructure/slack/gitea" | trim | quote }}
+aws_access_key_id     = {{ protonPass "pass://Unbound Infrastructure/gitea/TerraformKey" | trim | quote }}
+aws_secret_access_key = {{ protonPass "pass://Unbound Infrastructure/gitea/TerraformSecret" | trim | quote }}
+schemas_api_key       = {{ protonPass "pass://Unbound Infrastructure/gitea/SchemasApiKey" | trim | quote }}
+acctest_token         = {{ protonPass "pass://Unbound Infrastructure/gitea/AcctestToken" | trim | quote }}
 # BUILDTOOLS_CONTENT per organization for K8s deployments
 # TODO: Fill in with actual deployment configuration
 buildtools_shiny = <<-EOF
@@ -17,7 +14,7 @@ registry:
   gitea:
     registry: oci.unbound.se
     username: buildtools
-    token: {{ regexFind "BuildtoolsToken:[^\n]*" $gitea | trimPrefix "BuildtoolsToken:" | trim }}
+    token: {{ protonPass "pass://Unbound Infrastructure/gitea/BuildtoolsToken" | trim }}
 targets:
   staging:
     context: k8s.unbound.se
@@ -35,7 +32,7 @@ registry:
   gitea:
     registry: oci.unbound.se
     username: buildtools
-    token: {{ regexFind "BuildtoolsToken:[^\n]*" $gitea | trimPrefix "BuildtoolsToken:" | trim }}
+    token: {{ protonPass "pass://Unbound Infrastructure/gitea/BuildtoolsToken" | trim }}
 targets:
   prod:
     context: k8s.unbound.se
@@ -52,7 +49,7 @@ registry:
   gitea:
     registry: oci.unbound.se
     username: buildtools
-    token: {{ regexFind "BuildtoolsToken:[^\n]*" $gitea | trimPrefix "BuildtoolsToken:" | trim }}
+    token: {{ protonPass "pass://Unbound Infrastructure/gitea/BuildtoolsToken" | trim }}
 targets:
   prod:
     context: k8s.unbound.se
@@ -66,7 +63,7 @@ registry:
   gitea:
     registry: oci.unbound.se
     username: buildtools
-    token: {{ regexFind "BuildtoolsToken:[^\n]*" $gitea | trimPrefix "BuildtoolsToken:" | trim }}
+    token: {{ protonPass "pass://Unbound Infrastructure/gitea/BuildtoolsToken" | trim }}
 cache:
   ecr:
     url: 724902258495.dkr.ecr.eu-west-1.amazonaws.com/buildcache
@@ -76,7 +73,7 @@ registry:
   gitea:
     registry: oci.unbound.se
     username: buildtools
-    token: {{ regexFind "BuildtoolsToken:[^\n]*" $gitea | trimPrefix "BuildtoolsToken:" | trim }}
+    token: {{ protonPass "pass://Unbound Infrastructure/gitea/BuildtoolsToken" | trim }}
 targets:
   prod:
     context: k8s.unbound.se

--- a/Source/Infrastructure/infra/gitlab/default.auto.tfvars.tmpl
+++ b/Source/Infrastructure/infra/gitlab/default.auto.tfvars.tmpl
@@ -1,3 +1,1 @@
-{{- $personal := "gA-ol5KM9A5u56gTKWJXhaSBin2Mtr8R6dM-LkL_mtMITW1sp9--i9p46CZevZtUrtB9Mi9VLpLQ8Y0U-JhNiw==" -}}
-{{- $auths := (protonPassJSON (print "pass://" $personal "/iI_F3jHzuiBM-hYOTcmXaSwjpHFOoztk4rVkDqpegXJE8_R7lnUNxhK2aRI8BDlFGbVb1eCNQsOZixj8xjq19Q==")).item.content.note -}}
-gitlab_token = {{ regexFind "GitlabTerraformToken:[^\n]*" $auths | trimPrefix "GitlabTerraformToken:" | trim | quote }}
+gitlab_token = {{ protonPass "pass://Personal/.auths/GitlabTerraformToken" | trim | quote }}

--- a/Source/dancefinder/dot_buildtools.yaml.tmpl
+++ b/Source/dancefinder/dot_buildtools.yaml.tmpl
@@ -1,7 +1,6 @@
-{{- $auths := (protonPassJSON "pass://Personal/.auths").item.content.note -}}
 registry:
   gitea:
     registry: oci.unbound.se
     username: argoyle
-    token: {{ regexFind "GiteaToken:[^\n]*" $auths | trimPrefix "GiteaToken:" -}}
+    token: {{ protonPass "pass://Personal/.auths/GiteaToken" | trim -}}
 

--- a/Source/dot_envrc.tmpl
+++ b/Source/dot_envrc.tmpl
@@ -6,8 +6,7 @@ export GITLAB_PRIVATE_TOKEN=${GITLAB_TOKEN}
 export CI_TOKEN=${GITLAB_TOKEN}
 export CI_REGISTRY_USER=git
 export CI_JOB_TOKEN=${GITLAB_TOKEN}
-{{- $ngrok := (protonPassJSON "pass://Personal/ngrok").item.content.note }}
-export NGROK_TOKEN={{ regexFind "token:[^\n]*" $ngrok | trimPrefix "token:" }}
+export NGROK_TOKEN={{ protonPass "pass://Personal/ngrok/token" | trim }}
 export NGROK_REGION=eu
 export NGROK_URL=https://usd.eu.ngrok.io
 export KUBECONFIG=$( IFS=:; set -- ${PWD}/.kube/kind*.yaml ${PWD}/.kube/*.yaml; echo "$*" )

--- a/Source/shiny/dot_envrc.tmpl
+++ b/Source/shiny/dot_envrc.tmpl
@@ -4,9 +4,7 @@ export GITLAB_USER=argoyle
 export CLUSTER_NAME=jocke
 export GOPRIVATE=gitea.unbound.se/shiny,gitea.unbound.se/unboundsoftware
 export AMQP_URL="amqp://user:password@unbound-control-plane.orb.local:5672/"
-{{ $schemas := (protonPassJSON "pass://Personal/schemas").item.content.note -}}
-{{ $cosmo := (protonPassJSON "pass://Personal/Cosmo").item.content.note -}}
-export API_KEY={{ regexFind "apiKey:[^\n]*" $schemas | trimPrefix "apiKey:" }}
+export API_KEY={{ protonPass "pass://Personal/schemas/apiKey" | trim }}
 export SCHEMA_REF=Shiny@dev
-export COSMO_API_KEY={{ regexFind "apiKey:[^\n]*" $cosmo | trimPrefix "apiKey:" }}
+export COSMO_API_KEY={{ protonPass "pass://Personal/Cosmo/apiKey" | trim }}
 PATH_add ./.bin

--- a/private_dot_auths.tmpl
+++ b/private_dot_auths.tmpl
@@ -1,6 +1,4 @@
-{{- $item := protonPassJSON "pass://Personal/.auths" -}}
-{{- $note := $item.item.content.note -}}
-export GITHUB_TOKEN={{ regexFind "GithubToken:[^\n]*" $note | trimPrefix "GithubToken:" }}
-export HOMEBREW_GITHUB_API_TOKEN={{ regexFind "GithubToken:[^\n]*" $note | trimPrefix "GithubToken:" }}
-export GITLAB_TOKEN={{ regexFind "GitlabToken:[^\n]*" $note | trimPrefix "GitlabToken:" }}
-export GITEA_TOKEN={{ regexFind "GiteaToken:[^\n]*" $note | trimPrefix "GiteaToken:" }}
+export GITHUB_TOKEN={{ protonPass "pass://Personal/.auths/GithubToken" | trim }}
+export HOMEBREW_GITHUB_API_TOKEN={{ protonPass "pass://Personal/.auths/GithubToken" | trim }}
+export GITLAB_TOKEN={{ protonPass "pass://Personal/.auths/GitlabToken" | trim }}
+export GITEA_TOKEN={{ protonPass "pass://Personal/.auths/GiteaToken" | trim }}

--- a/private_dot_netrc.tmpl
+++ b/private_dot_netrc.tmpl
@@ -1,5 +1,4 @@
-{{- $auths := (protonPassJSON "pass://Personal/.auths").item.content.note -}}
 machine gitlab.com
 login argoyle
-password {{ regexFind "GitlabToken:[^\n]*" $auths | trimPrefix "GitlabToken:" -}}
+password {{ protonPass "pass://Personal/.auths/GitlabToken" | trim -}}
 

--- a/private_dot_ngrok2/private_ngrok.yml.tmpl
+++ b/private_dot_ngrok2/private_ngrok.yml.tmpl
@@ -1,5 +1,4 @@
-{{- $ngrok := (protonPassJSON "pass://Personal/ngrok").item.content.note -}}
-authtoken: {{ regexFind "token:[^\n]*" $ngrok | trimPrefix "token:" }}
+authtoken: {{ protonPass "pass://Personal/ngrok/token" | trim }}
 region: eu
 tunnels:
     paidit:


### PR DESCRIPTION
## Summary
- Replace `protonPassJSON` + `regexFind` note parsing with direct `protonPass "pass://vault/item/field"` custom field access across all 16 template files
- Blob items (dockercfg, cloudamqp, firestore, harbour, infrasec certs) remain unchanged as their note IS the content
- Fixes a bug in GoodFeed `.envrc` where `BUILDKITE_API_TOKEN` and `GITHUB_TOKEN` were concatenated on one line

## Test plan
- [x] Verified with `chezmoi diff` — only expected diff is the GoodFeed bug fix (tokens now on separate lines)
- [x] All ProtonPass items updated with custom fields via `pass-cli` before template changes
- [ ] Run `chezmoi apply` on target machine to confirm deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)