### PR TITLE
docs: add stable claude binary path rule to subagent strategy

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -28,6 +28,7 @@
 - Offload research, exploration, and parallel analysis to subagents
 - For complex problems, throw more compute at it via subagents
 - One task per subagent for focused execution
+- When spawning agents/subprocesses that need the `claude` binary, ALWAYS use `/opt/homebrew/bin/claude` (the stable symlink), NEVER the versioned Caskroom path (`/opt/homebrew/Caskroom/claude-code/<version>/claude`) which breaks on upgrades
 
 ### Self-Improvement Loop
 - After ANY correction from the user: update auto-memory or the relevant CLAUDE.md with the pattern


### PR DESCRIPTION
## Summary
- Add rule to Subagent Strategy section: always use `/opt/homebrew/bin/claude` (stable symlink) instead of versioned Caskroom path which breaks on upgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)