### PR TITLE
fix: handle 'Setup required' error in but-pull-all

### DIFF
--- a/dot_functions
+++ b/dot_functions
@@ -150,6 +150,8 @@ but-pull-all() {
                 echo "$name: \033[31mtimed out during check\033[0m"
             elif echo "$check_output" | grep -q "Up to date"; then
                 echo "$name: \033[32mup to date\033[0m"
+            elif echo "$check_output" | grep -q "Setup required"; then
+                echo "$name: \033[33mnot initialized, skipping\033[0m"
             elif echo "$check_output" | grep -q "bad object"; then
                 # Broken refs detected
                 if [[ $force -eq 1 ]]; then


### PR DESCRIPTION
Skip projects that but reports as not initialized (stale entries, unapplied workspaces, case mismatches) instead of showing error output.