### PR TITLE
feat: add Gitea forge rules, PR guard hook, and debugging methodology

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -50,6 +50,9 @@
 - When given a bug report: just fix it — don't ask for hand-holding
 - Point at logs, errors, failing tests — then resolve them
 - Go fix failing CI tests without being told how
+- **Before diagnosing**: gather actual evidence first (logs, error messages, versions, recent changes)
+- **Form hypotheses, then verify** — never jump straight to code changes based on assumptions
+- If the first fix attempt fails, STOP and re-examine evidence from scratch — don't iterate on a wrong diagnosis
 
 ## Core Principles
 
@@ -63,9 +66,19 @@ When the current branch is `gitbutler/workspace`, use the `but` CLI instead of g
 
 - **Always pass `-C <repo-root>`** to every `but` command (e.g., `but -C /path/to/repo status`). This ensures the command targets the correct repository without relying on the current working directory. All examples below omit `-C` for brevity, but it must always be included.
 - **NEVER use `git push`** when on the `gitbutler/workspace` branch. Use `but push <branch>` instead.
+- **NEVER use `but pr` for Gitea remotes** — it will fail. Always use the Gitea REST API via curl.
 - **Create PRs using `but pr new <branch>`**:
   - **GitHub remotes**: Use `-m "title\n\nbody"` or `-F <file>` to set a custom title and body
   - **GitLab remotes**: Always use `-t` flag only (`but pr new -t <branch>`) — do not try to set a PR title or body
+  - **Gitea remotes** (git.unbound.se, git.nl.cloud): `but pr` does NOT support Gitea. Use the Gitea REST API directly:
+    ```bash
+    curl -sk -X POST \
+      -H "Authorization: token $GITEA_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"title":"PR title","head":"branch-name","base":"main"}' \
+      "https://<host>/api/v1/repos/<owner>/<repo>/pulls"
+    ```
+    Detect Gitea remotes by checking `git remote -v` for `git.unbound.se` or `git.nl.cloud`.
 
 ### Pre-Commit Analysis Workflow
 

--- a/private_dot_claude/hooks/executable_gitea-pr-guard.sh
+++ b/private_dot_claude/hooks/executable_gitea-pr-guard.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# PreToolUse hook: block `but pr` on Gitea-hosted repos.
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+# Only check but pr commands
+case "$command" in
+  *"but pr"*|*"but "*"pr "*) ;;
+  *) exit 0 ;;
+esac
+
+# Extract repo path from -C flag, fall back to cwd
+repo_path="."
+case "$command" in
+  *"-C "*)
+    repo_path=$(echo "$command" | sed 's/.*-C  *//' | sed 's/ .*//')
+    ;;
+esac
+
+origin_url=$(git -C "$repo_path" remote get-url origin 2>/dev/null || echo "")
+case "$origin_url" in
+  *git.unbound.se*|*git.nl.cloud*)
+    echo "Blocked: 'but pr' does not support Gitea ($origin_url). Use the Gitea REST API instead." >&2
+    exit 2
+    ;;
+esac
+exit 0

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -81,8 +81,51 @@
       "Bash(git -C * ls-files *)",
       "Bash(git config --get *)",
       "Bash(git config --list *)",
-      "Bash(git config --list)"
-    ]
+      "Bash(git config --list)",
+      "Bash(tree:*)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Bash(git -C /Users/argoyle/.local/share/chezmoi status)",
+      "Bash(git -C /Users/argoyle/.local/share/chezmoi diff --name-only)",
+      "Bash(time zsh:*)",
+      "Bash(find:*)",
+      "Bash(bash:*)",
+      "Bash(git -C /Users/argoyle/.local/share/chezmoi status --short)",
+      "Bash(brew info:*)",
+      "WebSearch",
+      "Bash(brew list:*)",
+      "WebFetch(domain:www.chezmoi.io)",
+      "Bash(pass-cli item list:*)",
+      "Bash(pass-cli item view:*)",
+      "Bash(/usr/local/bin/lpass show:*)",
+      "Bash(pass item get:*)",
+      "Bash(pass item list:*)",
+      "Bash(pass-cli vault list:*)",
+      "Bash(chezmoi diff:*)",
+      "Bash(lpass show:*)",
+      "Bash(grep:*)",
+      "Bash(lpass ls:*)",
+      "Bash(chezmoi cat:*)",
+      "WebFetch(domain:protonpass.github.io)",
+      "Bash(but --help:*)",
+      "Bash(but commit:*)",
+      "Bash(but branch:*)",
+      "WebFetch(domain:docs.gitbutler.com)",
+      "WebFetch(domain:blog.gitbutler.com)",
+      "WebFetch(domain:gist.github.com)",
+      "Bash(claude --version:*)",
+      "Bash(but status --json)",
+      "Bash(but status:*)",
+      "Bash(but pr new --help:*)",
+      "Bash(but pr --help:*)",
+      "Bash(chezmoi apply:*)",
+      "Bash(git add:*)",
+      "Bash(pre-commit run:*)",
+      "WebFetch(domain:cli.github.com)"
+    ],
+    "deny": [],
+    "ask": [],
+    "defaultMode": "default"
   },
   "hooks": {
     "PreToolUse": [
@@ -97,6 +140,11 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/gh-api-readonly.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/gitea-pr-guard.sh",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary
- Add Gitea remote detection and REST API PR creation workflow to global CLAUDE.md (addresses #1 friction source: 65 of 191 repos are Gitea-hosted)
- Add `gitea-pr-guard.sh` PreToolUse hook that blocks `but pr` on Gitea repos (defense-in-depth)
- Strengthen autonomous bug fixing section with evidence-gathering discipline
- Merge runtime-added permissions into chezmoi source for settings.json

## Test plan
- [x] Hook blocks `but pr` on Gitea repo (cwd-based detection)
- [x] Hook passes through `but pr` on GitHub repo
- [x] Hook blocks `but pr` with `-C` flag pointing to Gitea repo
- [x] Hook passes through `but pr` with `-C` flag pointing to GitHub repo
- [x] Hook ignores non-pr commands (`but push`, etc.)
- [x] `chezmoi diff ~/.claude/` shows no remaining drift