### PR TITLE
feat: add pre-commit guard hook to skip repos without config

### DIFF
--- a/private_dot_claude/hooks/executable_pre-commit-guard.sh
+++ b/private_dot_claude/hooks/executable_pre-commit-guard.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# PreToolUse hook: block `pre-commit run` when no .pre-commit-config.yaml exists.
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+# Only check pre-commit run commands
+case "$command" in
+  *"pre-commit run"*) ;;
+  *) exit 0 ;;
+esac
+
+# Extract repo path from -C flag or git add -C, fall back to cwd
+repo_path="."
+case "$command" in
+  *"-C "*)
+    repo_path=$(echo "$command" | sed 's/.*-C  *//' | sed 's/ .*//')
+    ;;
+esac
+
+# Resolve to git root if possible
+git_root=$(git -C "$repo_path" rev-parse --show-toplevel 2>/dev/null || echo "$repo_path")
+
+if [ ! -f "$git_root/.pre-commit-config.yaml" ]; then
+  echo "Blocked: no .pre-commit-config.yaml found in $git_root. Skipping pre-commit." >&2
+  exit 2
+fi
+exit 0

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -146,6 +146,11 @@
             "type": "command",
             "command": "~/.claude/hooks/gitea-pr-guard.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/pre-commit-guard.sh",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add `pre-commit-guard.sh` PreToolUse hook that checks for `.pre-commit-config.yaml` before allowing `pre-commit run`
- Blocks with exit 2 and clear message when no config exists, preventing noisy `InvalidConfigError` failures
- Registered in `settings.json` alongside existing hooks

## Test plan
- [x] Hook blocks `pre-commit run` in repo without `.pre-commit-config.yaml` (chezmoi)
- [x] Hook allows `pre-commit run` in repo with `.pre-commit-config.yaml` (accounting-service)
- [x] Hook ignores non-pre-commit commands