### PR TITLE
docs: add note that git.unbound.se API endpoint is gitea.unbound.se

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -79,6 +79,7 @@ When the current branch is `gitbutler/workspace`, use the `but` CLI instead of g
       "https://<host>/api/v1/repos/<owner>/<repo>/pulls"
     ```
     Detect Gitea remotes by checking `git remote -v` for `git.unbound.se` or `git.nl.cloud`.
+    **Note**: The HTTPS API endpoint for `git.unbound.se` repos is `gitea.unbound.se` (e.g., `https://gitea.unbound.se/api/v1/repos/...`).
 
 ### Pre-Commit Analysis Workflow
 


### PR DESCRIPTION
## Summary
- Add clarification that the HTTPS API endpoint for `git.unbound.se` repos is `gitea.unbound.se`
- Prevents using the wrong hostname when constructing Gitea REST API URLs from git remote output