### PR TITLE
docs: update but CLI reference for v0.19.4

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -136,6 +136,9 @@ When the current branch is `gitbutler/workspace`, use the `but` CLI instead of g
 | Command | Purpose |
 |---------|---------|
 | `but status --json` | Get workspace state with CLI IDs |
+| `but status -f` | Show status including committed files |
+| `but status -v` | Verbose output with commit author and timestamp |
+| `but status -u` | Show detailed upstream commits not yet integrated |
 | `but branch list --json` | Get existing branches |
 | `but diff` | Show all uncommitted diffs |
 | `but diff <cliId>` | Show diff for a file, branch, stack, or commit |
@@ -154,12 +157,17 @@ When the current branch is `gitbutler/workspace`, use the `but` CLI instead of g
 | `but commit --only -m "msg" <branch>` | Commit only assigned files to branch |
 | `but commit -c --only -m "msg"` | Create new branch and commit assigned files |
 | `but commit -p <cliId> -m "msg" <branch>` | Commit specific files/hunks only |
+| `but commit -i -m "msg" <branch>` | AI-generated commit message (optional summary after `--ai=`) |
 | `but commit empty --before <target>` | Insert blank placeholder commit before target |
+| `but commit empty --after <target>` | Insert blank placeholder commit after target |
 | `but mark <branch>` | Auto-stage new changes to this branch |
 | `but mark <commit>` | Auto-amend new changes into this commit |
+| `but mark -d <target>` | Delete a specific mark |
 | `but unmark` | Remove all marks |
 | `but apply <branch>` | Apply (enable) an unapplied branch |
+| `but unapply <branch>` | Unapply (stash) a branch from workspace |
 | `but discard <cliId>` | Discard uncommitted changes for a file/hunk |
+| `but branch delete <branch>` | Delete a branch |
 
 #### Editing Commits
 
@@ -171,6 +179,8 @@ When the current branch is `gitbutler/workspace`, use the `but` CLI instead of g
 | `but absorb <cliId>` | Absorb a specific uncommitted file into its matching commit |
 | `but absorb <branch>` | Absorb all changes staged to a specific branch |
 | `but absorb --dry-run` | Show absorption plan without making changes |
+| `but absorb --new` | Create new commits instead of amending existing ones |
+| `but amend <file> <commit>` | Amend file into commit (shorthand for `but rub <file> <commit>`) |
 | `but squash <branch>` | Squash all commits in branch into bottom-most |
 | `but squash <commit1> <commit2>` | Squash first commit into second |
 | `but squash <commit1>..<commit2>` | Squash commit range into last commit |
@@ -179,13 +189,27 @@ When the current branch is `gitbutler/workspace`, use the `but` CLI instead of g
 | `but uncommit <commit>` | Uncommit changes back to unstaged area |
 | `but pick <source> <target-branch>` | Cherry-pick from unapplied branch |
 
+#### Conflict Resolution
+
+| Command | Purpose |
+|---------|---------|
+| `but resolve <commit>` | Enter resolution mode for a conflicted commit |
+| `but resolve status` | Show remaining conflicted files |
+| `but resolve finish` | Finalize resolution and return to workspace |
+| `but resolve cancel` | Cancel resolution and return to workspace |
+
 #### Server Interactions
 
 | Command | Purpose |
 |---------|---------|
 | `but push <branch>` | Push branch to remote (use instead of `git push`) |
 | `but pr new -m "title\n\nbody" <branch>` | Create PR with custom title and body (GitHub only) |
+| `but pr new -d <branch>` | Create PR as draft |
 | `but pr new -t <branch>` | Create PR using commit message (required for GitLab) |
+| `but pr auto-merge <branch>` | Enable/disable auto-merge on a PR |
+| `but pr set-draft <branch>` | Set existing PR as draft |
+| `but pr set-ready <branch>` | Set existing PR as ready for review |
+| `but pr template` | Select PR description template from repo |
 | `but merge <branch>` | Merge a branch into local target branch |
 
 #### Operation History
@@ -194,6 +218,17 @@ When the current branch is `gitbutler/workspace`, use the `but` CLI instead of g
 |---------|---------|
 | `but undo` | Undo the last operation |
 | `but oplog` | View operation history |
+
+#### Other
+
+| Command | Purpose |
+|---------|---------|
+| `but alias add <name> <command>` | Create command shortcut |
+| `but alias remove <name>` | Remove a command shortcut |
+| `but alias list` | List all aliases |
+| `but skill install` | Install GitButler AI skill files for coding agents |
+| `but skill check` | Check if installed skills are up to date |
+| `but update check` | Check for new CLI version |
 
 ### Rub Operations Matrix
 
@@ -204,7 +239,9 @@ When the current branch is `gitbutler/workspace`, use the `but` CLI instead of g
 | File/Hunk | Unstage | Amend | Stage | Stage |
 | Commit | Undo | Squash | Move | - |
 | Branch (all) | Unstage all | Amend all | Reassign | Reassign |
+| Stack (all) | Unstage all | - | Reassign | Reassign |
 | Unassigned (zz) | - | Amend all | Stage all | Stage all |
+| File-in-Commit | Uncommit | Move | Uncommit to | - |
 
 ### CLI ID Format
 


### PR DESCRIPTION
## Summary
- Add new commands: `resolve`, `amend`, `skill`, `alias`, `update`, `unapply`, `branch delete`
- Add new `pr` subcommands: `auto-merge`, `set-draft`, `set-ready`, `template`, `-d` (draft)
- Add new flags: `commit --ai`, `absorb --new`, `status -f/-v/-u`, `mark -d`
- Update rub operations matrix with `File-in-Commit` and `Stack (all)` rows