### PR TITLE
docs: add git.nl.cloud API endpoint note to chezmoi source

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -80,6 +80,7 @@ When the current branch is `gitbutler/workspace`, use the `but` CLI instead of g
     ```
     Detect Gitea remotes by checking `git remote -v` for `git.unbound.se` or `git.nl.cloud`.
     **Note**: The HTTPS API endpoint for `git.unbound.se` repos is `gitea.unbound.se` (e.g., `https://gitea.unbound.se/api/v1/repos/...`).
+    **Note**: The HTTPS API endpoint for `git.nl.cloud` repos is `https://git.nl.cloud:8443` (e.g., `https://git.nl.cloud:8443/api/v1/repos/...`).
 
 ### Pre-Commit Analysis Workflow
 


### PR DESCRIPTION
## Summary
- Incorporate out-of-band change: `git.nl.cloud` uses port 8443 for its HTTPS API endpoint
- Syncs chezmoi source with deployed `~/.claude/CLAUDE.md` that was edited directly by another session