### PR TITLE
feat: enable gobuildcache for shared S3 build cache with CI

### DIFF
--- a/Source/dot_envrc.tmpl
+++ b/Source/dot_envrc.tmpl
@@ -1,6 +1,12 @@
 unset $(compgen -v | grep "AWS_")
 export AWS_CONFIG_FILE=${PWD}/.aws/config
 export AWS_SSO_CONFIG=${PWD}/.aws-sso/config
+# Go remote build cache (shared with CI)
+export AWS_DEFAULT_PROFILE=unbound
+export AWS_REGION=eu-west-1
+export GOCACHEPROG=$HOME/go/bin/gobuildcache
+export GOBUILDCACHE_BACKEND_TYPE=s3
+export GOBUILDCACHE_S3_BUCKET=gobuildcache.unbound.se
 export KOPS_STATE_STORE=s3://724902258495-eu-west-1-kops-storage
 export GITLAB_PRIVATE_TOKEN=${GITLAB_TOKEN}
 export CI_TOKEN=${GITLAB_TOKEN}

--- a/run_once_add_gobuildcache.sh
+++ b/run_once_add_gobuildcache.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+export PATH="$HOME/.gobrew/current/bin:$HOME/.gobrew/bin:$PATH"
+gobrew use latest
+
+go install github.com/richardartoul/gobuildcache@latest


### PR DESCRIPTION
## Summary

- Add `run_once_add_gobuildcache.sh` to install the gobuildcache binary via `go install`
- Configure `Source/dot_envrc.tmpl` with S3-backed Go build cache environment variables
- Uses `AWS_DEFAULT_PROFILE=unbound` (not `AWS_PROFILE`) to avoid conflict with `aws-sso-profile` function
- Shares the same S3 bucket (`gobuildcache.unbound.se`) and config as CI runners
- Falls back silently to local cache if AWS SSO session is expired