### PR TITLE
fix: update Intersolia 1Password vault from Vector to Ester

### DIFF
--- a/Source/CustomerProjects/Intersolia/infrastructure/terraform/environments/dev/default.auto.tfvars.tmpl
+++ b/Source/CustomerProjects/Intersolia/infrastructure/terraform/environments/dev/default.auto.tfvars.tmpl
@@ -1,1 +1,1 @@
-cloudamqp_api_key = {{ onepasswordRead "op://Vector Secrets/Terraform Secrets/cloudamqp" | quote }}
+cloudamqp_api_key = {{ onepasswordRead "op://Ester Secrets/Terraform Secrets/cloudamqp" | quote }}

--- a/Source/CustomerProjects/Intersolia/infrastructure/terraform/environments/prod/default.auto.tfvars.tmpl
+++ b/Source/CustomerProjects/Intersolia/infrastructure/terraform/environments/prod/default.auto.tfvars.tmpl
@@ -1,1 +1,1 @@
-cloudamqp_api_key = {{ onepasswordRead "op://Vector Secrets/Terraform Secrets/cloudamqp" | quote }}
+cloudamqp_api_key = {{ onepasswordRead "op://Ester Secrets/Terraform Secrets/cloudamqp" | quote }}


### PR DESCRIPTION
## Summary

- Update 1Password vault reference from `Vector Secrets` to `Ester Secrets` in both dev and prod tfvars templates
- Fixes `chezmoi apply` failure caused by vault rename