### PR TITLE
docs: add pull-and-resolve-before-push step to GitButler workflow

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -129,6 +129,10 @@ When the current branch is `gitbutler/workspace`, use the `but` CLI instead of g
    - **IMPORTANT**: Always use `--only` flag to commit only the assigned files
    - Without `--only`, all staged files will be committed regardless of branch assignment
 6. Follow conventional commits format
+7. **Pull and resolve before pushing**: `but pull` again before `but push <branch>`
+   - Always pull to rebase on top of any new upstream changes before pushing
+   - If conflicts arise, resolve them with `but resolve <commit>`, fix files, then `but resolve finish`
+   - Only push after a clean pull with no conflicts
 
 ### Key Commands Reference
 


### PR DESCRIPTION
## Summary
- Add step 7 to the commit workflow: always pull and resolve conflicts before pushing
- Ensures branches rebase cleanly on upstream before going to remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)