### PR TITLE
feat: add GitButler CLI PATH and completions to zshrc

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -107,3 +107,7 @@ typeset -U manpath
 fpath+=~/.zfunc; autoload -Uz compinit; compinit
 
 setopt CLOBBER
+
+# GitButler CLI
+export PATH="/Users/argoyle/.local/bin:$PATH"
+eval "$(but completions zsh)"


### PR DESCRIPTION
## Summary
- Incorporate GitButler installer changes into chezmoi-managed zshrc
- Adds ~/.local/bin to PATH and enables but shell completions

🤖 Generated with [Claude Code](https://claude.com/claude-code)