### PR TITLE
refactor: simplify tmux notify hook to bell-only

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -102,8 +102,6 @@ setw -g window-status-current-format ' #I#[fg=colour250]:#[fg=colour255]#W#[fg=c
 setw -g window-status-style fg=colour138,bg=colour235,none
 setw -g window-status-format ' #I#[fg=colour237]:#[fg=colour250]#W#[fg=colour244]#F '
 
-setw -g window-status-bell-style bold,fg=colour255,bg=colour1
-
 # }
 # The messages {
 
@@ -132,5 +130,10 @@ set -g @catppuccin_window_current_text " #W#{?window_bell_flag, !,}"
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'
 
-# Override bell style after catppuccin loads (catppuccin overrides window styles)
-setw -g window-status-bell-style "bold,fg=colour255,bg=colour1"
+# Bell-colored window tabs: catppuccin replaces window-status-format with
+# inline colors, making window-status-bell-style ineffective. We store two
+# format variants (bell=red, normal=default) as user variables, then use a
+# conditional in window-status-format to pick the right one.
+set -g @window_fmt_bell "#[fg=#11111b,bg=#{E:@thm_red}]#[fg=#181825,reverse]#[none]#I #[fg=#cdd6f4,bg=#{E:@thm_red}] #W !#[fg=#181825,reverse]#[none]"
+set -g @window_fmt_normal "#[fg=#11111b,bg=#{@thm_overlay_2}]#[fg=#181825,reverse]#[none]#I #[fg=#cdd6f4,bg=#{@thm_surface_0}] #W#[fg=#181825,reverse]#[none]"
+set -g window-status-format '#{?window_bell_flag,#{E:@window_fmt_bell},#{E:@window_fmt_normal}}'

--- a/private_dot_claude/hooks/executable_tmux-notify.sh
+++ b/private_dot_claude/hooks/executable_tmux-notify.sh
@@ -13,12 +13,7 @@ pane_tty=$(tmux display-message -p -t "$TMUX_PANE" '#{pane_tty}')
 event=$(cat | jq -r '.hook_event_name // empty')
 
 case "$event" in
-    Stop)
-        tmux display-message -t "$TMUX_PANE" "Claude finished responding"
-        printf '\a' > "$pane_tty"
-        ;;
-    Notification)
-        tmux display-message -t "$TMUX_PANE" "Claude is waiting for input"
+    Stop|Notification)
         printf '\a' > "$pane_tty"
         ;;
 esac


### PR DESCRIPTION
Remove intrusive `tmux display-message` overlay from Claude Code hook.
The bell signal alone is sufficient — tmux's `monitor-bell` highlights
the window tab in red when Claude needs input or finishes a task.