### PR TITLE
feat: add Go private module env vars for Frostmoln

### DIFF
--- a/Source/Frostmoln/dot_envrc.tmpl
+++ b/Source/Frostmoln/dot_envrc.tmpl
@@ -1,1 +1,4 @@
 export GITEA_TOKEN={{ protonPass "pass://Personal/git.nl.cloud/Token" | trim | quote }}
+export GOPRIVATE="git.nl.cloud/*"
+export GONOSUMCHECK="git.nl.cloud/*"
+export GOINSECURE="git.nl.cloud"


### PR DESCRIPTION
## Summary
- Add `GOPRIVATE`, `GONOSUMCHECK`, and `GOINSECURE` env vars for `git.nl.cloud` to Frostmoln's `.envrc`
- Enables Go module fetching from the private Gitea instance