### PR TITLE
feat: make GOCACHEPROG available globally via wrapper script

### DIFF
--- a/Source/dot_envrc.tmpl
+++ b/Source/dot_envrc.tmpl
@@ -4,9 +4,6 @@ export AWS_SSO_CONFIG=${PWD}/.aws-sso/config
 # Go remote build cache (shared with CI)
 export AWS_DEFAULT_PROFILE=unbound
 export AWS_REGION=eu-west-1
-export GOCACHEPROG=$HOME/go/bin/gobuildcache
-export GOBUILDCACHE_BACKEND_TYPE=s3
-export GOBUILDCACHE_S3_BUCKET=gobuildcache.unbound.se
 export KOPS_STATE_STORE=s3://724902258495-eu-west-1-kops-storage
 export GITLAB_PRIVATE_TOKEN=${GITLAB_TOKEN}
 export CI_TOKEN=${GITLAB_TOKEN}

--- a/dot_bin/executable_gobuildcache-wrapper
+++ b/dot_bin/executable_gobuildcache-wrapper
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Wrapper for gobuildcache that ensures S3 access via the unbound AWS profile,
+# regardless of which directory's .envrc is active.
+export AWS_CONFIG_FILE="${HOME}/Source/.aws/config"
+export AWS_PROFILE=unbound
+export AWS_REGION=eu-west-1
+export GOBUILDCACHE_BACKEND_TYPE=s3
+export GOBUILDCACHE_S3_BUCKET=gobuildcache.unbound.se
+exec "${HOME}/go/bin/gobuildcache" "$@"

--- a/dot_exports
+++ b/dot_exports
@@ -29,5 +29,8 @@ export RABBITMQ_PASSWORD=password
 
 export BASH_ENV=${HOME}/.bashrc
 
+# Go remote build cache (shared with CI) — wrapper handles AWS credentials
+export GOCACHEPROG=$HOME/.bin/gobuildcache-wrapper
+
 # Required for pinentry/GPG to work correctly in tmux
 export GPG_TTY=$(tty)

--- a/dot_paths
+++ b/dot_paths
@@ -16,5 +16,6 @@ prepend_path $HOME/.local/bin
 prepend_path $HOME/.gobrew/bin
 prepend_path $HOME/.gobrew/current/bin
 prepend_path $HOME/go/bin
+prepend_path $HOME/.bin
 prepend_path /opt/homebrew/opt/helm@3/bin
 append_path $(gem env gemdir)/bin


### PR DESCRIPTION
Move Go build cache config out of Source/.envrc into a dedicated wrapper script that sets AWS credentials independently. This ensures gobuildcache can access the S3 bucket regardless of the active direnv AWS profile.

Changes:
- Add ~/.bin/gobuildcache-wrapper with hardcoded unbound AWS profile and S3 config
- Set GOCACHEPROG globally in .exports (was only in Source/.envrc)
- Add ~/.bin to PATH
- Remove GOCACHEPROG/S3 vars from Source/.envrc