### PR TITLE
feat: use static AWS credentials for gobuildcache wrapper

### DIFF
--- a/dot_bin/executable_gobuildcache-wrapper
+++ b/dot_bin/executable_gobuildcache-wrapper
@@ -1,9 +1,0 @@
-#!/bin/sh
-# Wrapper for gobuildcache that ensures S3 access via the unbound AWS profile,
-# regardless of which directory's .envrc is active.
-export AWS_CONFIG_FILE="${HOME}/Source/.aws/config"
-export AWS_PROFILE=unbound
-export AWS_REGION=eu-west-1
-export GOBUILDCACHE_BACKEND_TYPE=s3
-export GOBUILDCACHE_S3_BUCKET=gobuildcache.unbound.se
-exec "${HOME}/go/bin/gobuildcache" "$@"

--- a/dot_bin/executable_gobuildcache-wrapper.tmpl
+++ b/dot_bin/executable_gobuildcache-wrapper.tmpl
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Wrapper for gobuildcache that ensures S3 access using static credentials,
+# avoiding SSO session timeout issues.
+export AWS_ACCESS_KEY_ID={{ protonPass "pass://Unbound Infrastructure/gobuildcache/accessKeyId" | trim | quote }}
+export AWS_SECRET_ACCESS_KEY={{ protonPass "pass://Unbound Infrastructure/gobuildcache/secretAccessKey" | trim | quote }}
+export AWS_REGION=eu-west-1
+export GOBUILDCACHE_BACKEND_TYPE=s3
+export GOBUILDCACHE_S3_BUCKET=gobuildcache.unbound.se
+exec "${HOME}/go/bin/gobuildcache" "$@"


### PR DESCRIPTION
## Summary

- Convert gobuildcache-wrapper to chezmoi template
- Replace AWS SSO profile with static IAM credentials from ProtonPass
- Avoids GOCACHEPROG failures when SSO session times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)