### PR TITLE
fix: add Go private module config and git insteadOf for private registries

### DIFF
--- a/dot_exports
+++ b/dot_exports
@@ -32,5 +32,10 @@ export BASH_ENV=${HOME}/.bashrc
 # Go remote build cache (shared with CI) — wrapper handles AWS credentials
 export GOCACHEPROG=$HOME/.bin/gobuildcache-wrapper
 
+# Go private modules (git.nl.cloud = NordicLight, gitea.unbound.se = Unbound)
+export GOPRIVATE="git.nl.cloud/*,gitea.unbound.se/*"
+export GONOSUMCHECK="git.nl.cloud/*,gitea.unbound.se/*"
+export GOINSECURE="git.nl.cloud,gitea.unbound.se"
+
 # Required for pinentry/GPG to work correctly in tmux
 export GPG_TTY=$(tty)

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -146,6 +146,14 @@
 
 [url "ssh://git@gitlab.com/"]
   insteadOf = https://gitlab.com/
+
+[url "ssh://git@git.nl.cloud:2222/"]
+  insteadOf = http://git.nl.cloud/
+  insteadOf = https://git.nl.cloud/
+
+[url "ssh://git@git.unbound.se/"]
+  insteadOf = http://gitea.unbound.se/
+  insteadOf = https://gitea.unbound.se/
 {{- end }}
 
 [includeIf "gitdir:~/Source/CustomerProjects/Keenfinity/"]


### PR DESCRIPTION
Add GOPRIVATE/GONOSUMCHECK/GOINSECURE for git.nl.cloud/* and gitea.unbound.se/* to dot_exports, and git url insteadOf rules to rewrite HTTP(S) to SSH for both hosts. Ensures Go module fetching works in non-interactive shells (CI, Claude Code, etc.).