### PR TITLE
feat: add persistent tmux bell notifications with jump-to-bell keybinding

### DIFF
--- a/dot_local/bin/executable_tmux-bell-notify
+++ b/dot_local/bin/executable_tmux-bell-notify
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Send a macOS notification when a tmux bell fires.
+# Called by tmux alert-bell hook with: "#S" "#W" "#I"
+# Also sets persistent @bell marker for tmux-jump-bell.
+
+SESSION="${1:-?}"
+WINDOW="${2:-?}"
+INDEX="${3:-?}"
+
+# Set persistent @bell marker (window_bell_flag is transient)
+tmux set-option -w -t "${SESSION}:${INDEX}" @bell 1
+
+TITLE="tmux: ${SESSION}:${INDEX}"
+MSG="${WINDOW} needs attention"
+
+if command -v terminal-notifier &>/dev/null; then
+  terminal-notifier \
+    -title "$TITLE" \
+    -message "$MSG" \
+    -sound Blow \
+    -activate com.mitchellh.ghostty
+  exit 0
+fi
+
+osascript -e "display notification \"$MSG\" with title \"$TITLE\"" 2>/dev/null || true

--- a/dot_local/bin/executable_tmux-jump-bell
+++ b/dot_local/bin/executable_tmux-jump-bell
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Jump to the next tmux window with @bell set, wrapping around.
+# Does nothing if no window has a pending bell.
+
+current=$(tmux display-message -p '#{window_index}')
+session=$(tmux display-message -p '#{session_name}')
+
+targets=$(tmux list-windows -t "$session" \
+  -F '#{window_index} #{@bell}' \
+  | awk '$2==1 {print $1}')
+
+[ -z "$targets" ] && exit 0
+
+# First index after current
+next=$(echo "$targets" | awk -v cur="$current" '$1 > cur { print $1; exit }')
+
+# Wrap to first bell window if nothing found after current
+if [ -z "$next" ]; then
+  next=$(echo "$targets" | head -1)
+fi
+
+tmux select-window -t "$session:$next"

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -83,6 +83,15 @@ set-window-option -g monitor-activity off
 set-window-option -g monitor-bell on
 set-option -g bell-action other
 
+# Bell handling: notify + set persistent @bell marker
+set-hook -g alert-bell "run-shell '$HOME/.local/bin/tmux-bell-notify \"#S\" \"#W\" \"#I\"'"
+
+# Clear @bell marker when a pane gets focus (works for mouse, keys, and prefix)
+set-hook -g pane-focus-in "set-option -w -q @bell 0"
+
+# Jump to next window with pending bell (prefix + b)
+bind b run-shell '$HOME/.local/bin/tmux-jump-bell'
+
 # The modes {
 setw -g clock-mode-colour colour135
 
@@ -124,16 +133,8 @@ set -g @continuum-restore 'on'
 
 set -g @catppuccin_flavor 'mocha'
 set -g @catppuccin_window_status_style "rounded"
-set -g @catppuccin_window_text " #W#{?window_bell_flag, !,}"
-set -g @catppuccin_window_current_text " #W#{?window_bell_flag, !,}"
+set -g @catppuccin_window_text "#{?@bell,#[fg=colour255 bg=colour1 bold] #W , #W}"
+set -g @catppuccin_window_current_text "#{?@bell,#[fg=colour255 bg=colour1 bold] #W , #W}"
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'
-
-# Bell-colored window tabs: catppuccin replaces window-status-format with
-# inline colors, making window-status-bell-style ineffective. We store two
-# format variants (bell=red, normal=default) as user variables, then use a
-# conditional in window-status-format to pick the right one.
-set -g @window_fmt_bell "#[fg=#11111b,bg=#{E:@thm_red}]#[fg=#181825,reverse]#[none]#I #[fg=#cdd6f4,bg=#{E:@thm_red}] #W !#[fg=#181825,reverse]#[none]"
-set -g @window_fmt_normal "#[fg=#11111b,bg=#{@thm_overlay_2}]#[fg=#181825,reverse]#[none]#I #[fg=#cdd6f4,bg=#{@thm_surface_0}] #W#[fg=#181825,reverse]#[none]"
-set -g window-status-format '#{?window_bell_flag,#{E:@window_fmt_bell},#{E:@window_fmt_normal}}'


### PR DESCRIPTION
Adds persistent @bell window markers, macOS notifications via terminal-notifier/osascript,
and prefix+b to jump to the next window needing attention. Replaces the old transient
window_bell_flag approach with a pane-focus-in hook that clears markers on focus.