### PR TITLE
feat: use catppuccin pill-style status modules for date and time

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -101,8 +101,7 @@ setw -g clock-mode-colour colour135
 set -g status-position bottom
 set -g status-style bg=colour234,fg=colour137,dim
 set -g status-left ''
-set -g status-right '#[fg=colour233,bg=colour241,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M:%S '
-set -g status-right-length 50
+set -g status-right-length 100
 set -g status-left-length 20
 
 setw -g window-status-current-style fg=colour81,bg=colour238,bold
@@ -136,5 +135,11 @@ set -g @catppuccin_window_status_style "rounded"
 set -g @catppuccin_window_text "#{?@bell,#[fg=colour255 bg=colour1 bold] #W , #W}"
 set -g @catppuccin_window_current_text "#{?@bell,#[fg=colour255 bg=colour1 bold] #W , #W}"
 
+# Status right: date and time in catppuccin pill style
+set -g @catppuccin_date_time_text " %d/%m  %H:%M:%S"
+
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'
+
+# Load catppuccin status modules (must be after TPM initializes the plugin)
+set -g status-right "#{E:@catppuccin_status_date_time}"


### PR DESCRIPTION
Replace manual status-right formatting with catppuccin's date_time
status module so the date/time matches the rounded pill style of
window tabs.