### PR TITLE
feat: prompt user for approval on gh api write operations instead of blocking

### DIFF
--- a/private_dot_claude/hooks/executable_gh-api-readonly.sh
+++ b/private_dot_claude/hooks/executable_gh-api-readonly.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# PreToolUse hook: allow only read-only (GET) gh api calls.
-# Blocks POST, PUT, DELETE, PATCH and data-mutation flags.
+# PreToolUse hook: prompt user for approval on write gh api calls.
+# Read-only calls pass through; writes trigger a user confirmation prompt.
 
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
@@ -11,16 +11,29 @@ case "$command" in
   *) exit 0 ;;
 esac
 
-# Block explicit write methods: -X POST, --method DELETE, etc.
+reason=""
+
+# Detect explicit write methods: -X POST, --method DELETE, etc.
 if echo "$command" | grep -qEi '(\s|^)-X\s*(POST|PUT|DELETE|PATCH)|\s--method\s+(POST|PUT|DELETE|PATCH)'; then
-  echo "Blocked: only read-only (GET) gh api calls are allowed" >&2
-  exit 2
+  reason="GitHub API write operation detected"
 fi
 
-# Block data flags that imply mutation (-d, -f, --raw-field, --field, --input)
-if echo "$command" | grep -qE '\s(-d|--raw-field|-f|--field|--input)\s'; then
-  echo "Blocked: data flags (-d, -f, --input) imply a write operation" >&2
-  exit 2
+# Detect data flags that imply mutation (-d, -f, --raw-field, --field, --input)
+if [ -z "$reason" ] && echo "$command" | grep -qE '\s(-d|--raw-field|-f|--field|--input)\s'; then
+  reason="GitHub API data flags detected (implies write operation)"
 fi
 
+# No write indicators found — allow
+[ -z "$reason" ] && exit 0
+
+# Prompt user for approval instead of hard-blocking
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "$reason"
+  }
+}
+EOF
 exit 0


### PR DESCRIPTION
Replace hard-block (exit 2) with permissionDecision "ask" so write
operations prompt the user for approval instead of being silently rejected.