### PR TITLE
docs: require but apply on Renovate branch before investigating upgrade issues

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -14,6 +14,7 @@
 - Always add unit tests when making changes, if possible
 - Always create a new branch for new work; never reuse merged branches
 - Prefer existing Renovate branches for dependency updates — do not manually edit dependency files (`go.mod`, `package.json`, etc.) when Renovate has already created a branch
+- When investigating Renovate upgrade problems, always `but apply` the Renovate branch first to get its changes before diagnosing or fixing
 - Go: always return empty slices (`[]`), never nil slices — nil serializes to JSON `null` and crashes frontends
 - Go: always handle errcheck — wrap `json.Encode`, `json.NewEncoder().Encode()`, and similar calls with error checks
 - Go: use `go mod tidy`, not manual `go.mod`/`go.sum` edits


### PR DESCRIPTION
## Summary
- Add rule to always `but apply` the Renovate branch before diagnosing upgrade problems
- Ensures fixes are made on top of Renovate's changes rather than starting from scratch

🤖 Generated with [Claude Code](https://claude.com/claude-code)