### PR TITLE
refactor: rename git.nl.cloud to git.sm.internal across all configs

### DIFF
--- a/Source/Frostmoln/dot_envrc.tmpl
+++ b/Source/Frostmoln/dot_envrc.tmpl
@@ -1,7 +1,7 @@
 source_up .envrc
 use nvm
 layout pyenv 3.14.0
-export GITEA_TOKEN={{ protonPass "pass://Personal/git.nl.cloud/Token" | trim | quote }}
-export GOPRIVATE="git.nl.cloud/*"
-export GONOSUMCHECK="git.nl.cloud/*"
-export GOINSECURE="git.nl.cloud"
+export GITEA_TOKEN={{ protonPass "pass://Personal/git.sm.internal/Token" | trim | quote }}
+export GOPRIVATE="git.sm.internal/*"
+export GONOSUMCHECK="git.sm.internal/*"
+export GOINSECURE="git.sm.internal"

--- a/dot_exports
+++ b/dot_exports
@@ -32,10 +32,10 @@ export BASH_ENV=${HOME}/.bashrc
 # Go remote build cache (shared with CI) — wrapper handles AWS credentials
 export GOCACHEPROG=$HOME/.bin/gobuildcache-wrapper
 
-# Go private modules (git.nl.cloud = NordicLight, gitea.unbound.se = Unbound)
-export GOPRIVATE="git.nl.cloud/*,gitea.unbound.se/*"
-export GONOSUMCHECK="git.nl.cloud/*,gitea.unbound.se/*"
-export GOINSECURE="git.nl.cloud,gitea.unbound.se"
+# Go private modules (git.sm.internal = NordicLight, gitea.unbound.se = Unbound)
+export GOPRIVATE="git.sm.internal/*,gitea.unbound.se/*"
+export GONOSUMCHECK="git.sm.internal/*,gitea.unbound.se/*"
+export GOINSECURE="git.sm.internal,gitea.unbound.se"
 
 # Required for pinentry/GPG to work correctly in tmux
 export GPG_TTY=$(tty)

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -147,9 +147,9 @@
 [url "ssh://git@gitlab.com/"]
   insteadOf = https://gitlab.com/
 
-[url "ssh://git@git.nl.cloud:2222/"]
-  insteadOf = http://git.nl.cloud/
-  insteadOf = https://git.nl.cloud/
+[url "ssh://git@git.sm.internal:2222/"]
+  insteadOf = http://git.sm.internal/
+  insteadOf = https://git.sm.internal/
 
 [url "ssh://git@git.unbound.se/"]
   insteadOf = http://gitea.unbound.se/

--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -111,7 +111,7 @@ For full command reference, see `~/.claude/gitbutler-reference.md`.
 - **Create PRs using `but pr new <branch>`**:
   - **GitHub remotes**: Use `-m "title\n\nbody"` or `-F <file>`
   - **GitLab remotes**: Always use `-t` flag only
-  - **Gitea remotes** (git.unbound.se, git.nl.cloud): Use Gitea REST API directly:
+  - **Gitea remotes** (git.unbound.se, git.sm.internal): Use Gitea REST API directly:
     ```bash
     curl -sk -X POST \
       -H "Authorization: token $GITEA_TOKEN" \
@@ -119,7 +119,7 @@ For full command reference, see `~/.claude/gitbutler-reference.md`.
       -d '{"title":"PR title","head":"branch-name","base":"main"}' \
       "https://<host>/api/v1/repos/<owner>/<repo>/pulls"
     ```
-    API endpoint for `git.unbound.se` is `gitea.unbound.se`. For `git.nl.cloud` it's `https://git.nl.cloud:8443`.
+    API endpoint for `git.unbound.se` is `gitea.unbound.se`. For `git.sm.internal` it's `https://git.sm.internal:8443`.
 - **PR management**: `but pr auto-merge <branch>` to enable auto-merge, `but pr set-draft`/`but pr set-ready` to toggle draft status
 
 ### Pre-Commit Analysis Workflow

--- a/private_dot_claude/commands/batch-update.md
+++ b/private_dot_claude/commands/batch-update.md
@@ -42,7 +42,7 @@ If the arguments are unclear, ask for clarification.
 
 ### Important Notes
 
-- **Frostmoln repos** are hosted on Gitea (`git.nl.cloud`). Use Gitea REST API for PRs, NOT `but pr`.
+- **Frostmoln repos** are hosted on Gitea (`git.sm.internal`). Use Gitea REST API for PRs, NOT `but pr`.
 - **Shiny/Unbound repos** are hosted on GitLab. Use `git push` and GitLab MR flow.
 - **Chezmoi-managed repos** use GitHub. Use `gh` or `but pr`.
 - Always read each file before editing — don't assume identical structure across repos.

--- a/private_dot_claude/hooks/executable_gitea-pr-guard.sh
+++ b/private_dot_claude/hooks/executable_gitea-pr-guard.sh
@@ -20,7 +20,7 @@ esac
 
 origin_url=$(git -C "$repo_path" remote get-url origin 2>/dev/null || echo "")
 case "$origin_url" in
-  *git.unbound.se*|*git.nl.cloud*)
+  *git.unbound.se*|*git.sm.internal*)
     echo "Blocked: 'but pr' does not support Gitea ($origin_url). Use the Gitea REST API instead." >&2
     exit 2
     ;;


### PR DESCRIPTION
Updates all references from `git.nl.cloud` to `git.sm.internal` following the Gitea instance migration:

- Git URL rewrites (SSH port 2222 preserved)
- Go private module settings (GOPRIVATE, GONOSUMCHECK, GOINSECURE)
- ProtonPass token path
- Claude Code instructions, hooks, and batch-update command
- Frostmoln project .envrc