### PR TITLE
chore: remove unused gitlab_provider_token from AWS tfvars

### DIFF
--- a/Source/Infrastructure/infra/aws/default.auto.tfvars.tmpl
+++ b/Source/Infrastructure/infra/aws/default.auto.tfvars.tmpl
@@ -11,7 +11,6 @@ slack = {
 docker_config                  = <<EOT
 {{ $dockercfg }}
 EOT
-gitlab_provider_token          = {{ protonPass "pass://Personal/.auths/GitlabTerraformToken" | trim | quote }}
 grafana_cloud_api_key          = {{ protonPass "pass://Unbound Infrastructure/grafana-cloud/terraform" | trim | quote }}
 grafana_oncall_token           = {{ protonPass "pass://Unbound Infrastructure/grafana-cloud/terraformOnCall" | trim | quote }}
 grafana_oncall_username        = "argoyle"


### PR DESCRIPTION
The `gitlab_provider_token` variable is declared in `aws/vars.tf` but never referenced by any Terraform resource or module. Removing the corresponding tfvars entry.