### PR TITLE
feat: add go.frostmoln.internal vanity import domain

### DIFF
--- a/dot_exports
+++ b/dot_exports
@@ -32,10 +32,10 @@ export BASH_ENV=${HOME}/.bashrc
 # Go remote build cache (shared with CI) — wrapper handles AWS credentials
 export GOCACHEPROG=$HOME/.bin/gobuildcache-wrapper
 
-# Go private modules (git.sm.internal = NordicLight, gitea.unbound.se = Unbound)
-export GOPRIVATE="git.sm.internal/*,gitea.unbound.se/*"
-export GONOSUMCHECK="git.sm.internal/*,gitea.unbound.se/*"
-export GOINSECURE="git.sm.internal,gitea.unbound.se"
+# Go private modules (git.sm.internal = Frostmoln, gitea.unbound.se = Unbound)
+export GOPRIVATE="git.sm.internal/*,go.frostmoln.internal/*,gitea.unbound.se/*"
+export GONOSUMCHECK="git.sm.internal/*,go.frostmoln.internal/*,gitea.unbound.se/*"
+export GOINSECURE="git.sm.internal,go.frostmoln.internal,gitea.unbound.se"
 
 # Required for pinentry/GPG to work correctly in tmux
 export GPG_TTY=$(tty)

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -151,6 +151,10 @@
   insteadOf = http://git.sm.internal/
   insteadOf = https://git.sm.internal/
 
+[url "ssh://git@git.sm.internal:2222/frostmoln/"]
+  insteadOf = http://go.frostmoln.internal/
+  insteadOf = https://go.frostmoln.internal/
+
 [url "ssh://git@git.unbound.se/"]
   insteadOf = http://gitea.unbound.se/
   insteadOf = https://gitea.unbound.se/


### PR DESCRIPTION
- Add `go.frostmoln.internal` to GOPRIVATE, GONOSUMCHECK, and GOINSECURE in exports
- Add git URL rewrite mapping `go.frostmoln.internal` → `ssh://git@git.sm.internal:2222/frostmoln/`
- Rename comment from "NordicLight" to "Frostmoln"