### PR TITLE
feat: enable automatic window renumbering in tmux

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -30,6 +30,7 @@ bind r source-file ~/.tmux.conf
 
 # Count sessions start at 1
 set -g base-index 1
+set-option -g renumber-windows on
 
 # Use vim bindings
 setw -g mode-keys vi


### PR DESCRIPTION
Adds `renumber-windows on` so closing a window automatically fills the gap in window indices, keeping numbering contiguous alongside `base-index 1`.