### PR TITLE
fix: guard pyenv lazy-init to prevent infinite recursion with pyenv-virtualenv 1.3.0

### DIFF
--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -17,8 +17,10 @@ export PATH=/opt/homebrew/opt/helm@3/bin:$PATH
 
 eval "$(direnv hook bash)"
 
-# Lazy-load pyenv for better startup performance
-if command -v pyenv 1>/dev/null 2>&1; then
+# Lazy-load pyenv for better startup performance (interactive shells only —
+# non-interactive sourcing via BASH_ENV would cause infinite recursion with
+# pyenv-virtualenv-init which calls `pyenv hooks` internally)
+if [[ $- == *i* ]] && command -v pyenv 1>/dev/null 2>&1; then
   export PYENV_ROOT="$HOME/.pyenv"
   export PATH="$PYENV_ROOT/bin:$PATH"
 


### PR DESCRIPTION
pyenv-virtualenv 1.3.0 added an internal `pyenv hooks version-name` call
in `pyenv-virtualenv-init`. Combined with `BASH_ENV=~/.bashrc`, this caused
infinite recursion: every non-interactive bash script sourced `.bashrc`,
defined the lazy pyenv wrapper, which called `pyenv virtualenv-init -`,
which spawned another bash script, ad infinitum.

Fix: guard the lazy-init with `[[ $- == *i* ]]` so it only runs in
interactive shells.