### PR TITLE
docs: add gofumpt, scope discipline, and repo verification rules from insights analysis

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -12,7 +12,12 @@
 - Always explicitly specify `--context <context>` when running kubectl commands. Check `.buildtools.yaml` or `.envrc` for the expected context. Never rely on the default — it may point to production.
 - Go: always return empty slices (`[]`), never nil slices — nil serializes to JSON `null`
 - Go: always handle errcheck
+- Go: always run `gofumpt -w .` on modified Go files before committing
+- Go: when modifying database migrations, always update MigrationExpectations in test mocks
 - Go: use `go mod tidy`, not manual `go.mod`/`go.sum` edits
+- Do ONLY what was asked — do not build, deploy, or run additional steps unless explicitly requested
+- Never fabricate Linear ticket references — always check if one exists first
+- Always verify you are in the correct repository directory before pushing or creating PRs
 
 ## Renovate
 


### PR DESCRIPTION
Based on Claude Code insights report analysis of 230 sessions:

- Go: run `gofumpt -w .` before committing (recurring CI failures)
- Go: update MigrationExpectations when modifying migrations
- Scope: do only what was asked — no unsolicited builds/deploys
- Linear: never fabricate ticket references, check first
- Git: verify correct repo directory before push/PR