### PR TITLE
chore: add GITHUB_TOKEN to Opzkit envrc from ProtonPass

### DIFF
--- a/Source/Opzkit/dot_envrc.tmpl
+++ b/Source/Opzkit/dot_envrc.tmpl
@@ -2,3 +2,5 @@ source_up .envrc
 
 export AWS_SSO_CONFIG=${PWD}/.aws-sso/config
 export AWS_CONFIG_FILE=${PWD}/.aws/config
+
+export GITHUB_TOKEN={{ protonPass "pass://Personal/Opzkit/GithubToken" | trim }}


### PR DESCRIPTION
Adds GITHUB_TOKEN environment variable to the Opzkit .envrc template, sourced from ProtonPass for secure secret management.