### PR TITLE
chore: add SSH keepalive config for 192.168.100.* subnet

### DIFF
--- a/private_dot_ssh/config
+++ b/private_dot_ssh/config
@@ -21,6 +21,10 @@ Host granvagen
   User root
   Port 2222
 
+Host 192.168.100.*
+  ServerAliveInterval 15
+  ServerAliveCountMax 3
+
 Host *
   User ubuntu
   StrictHostKeyChecking no


### PR DESCRIPTION
Incorporate out-of-band SSH keepalive settings (interval 15s, max 3) for the 192.168.100.* subnet into chezmoi source.