### PR TITLE
chore: add Ansible vault password for Falkenberg from ProtonPass

### DIFF
--- a/dot_ansible/vault-falkenberg.pw.tmpl
+++ b/dot_ansible/vault-falkenberg.pw.tmpl
@@ -1,0 +1,1 @@
+{{ protonPass "pass://Frostmoln shared/Ansible/Falkenberg" | trim }}


### PR DESCRIPTION
Add vault-falkenberg.pw template that retrieves the Ansible vault password from ProtonPass.