### PR TITLE
feat: add Wireguard private key from ProtonPass

### DIFF
--- a/private_dot_secrets/private_wireguard/private_joakim.key.tmpl
+++ b/private_dot_secrets/private_wireguard/private_joakim.key.tmpl
@@ -1,0 +1,1 @@
+{{ protonPass "pass://Personal/Wireguard/PrivateKey" | trim }}


### PR DESCRIPTION
Add chezmoi template that retrieves the personal Wireguard private key from ProtonPass and deploys it to ~/.secrets/wireguard/joakim.key with mode 600.