### PR TITLE
chore: add sshpass and winbox to Brewfile

### DIFF
--- a/dot_local/share/Brewfile.tmpl
+++ b/dot_local/share/Brewfile.tmpl
@@ -145,6 +145,7 @@ brew "rbenv"
 brew "schpet/tap/linear"
 brew "socat"
 brew "ssh-copy-id", link: true
+brew "sshpass"
 brew "stategraph/stategraph/stategraph"
 brew "stern"
 brew "swagger-codegen"


### PR DESCRIPTION
Add sshpass formula (all machines) and winbox cask (gwaihir only) for SSH password auth and MikroTik RouterOS administration.