### PR TITLE
feat: add GitHub token to ProductQuest envrc

### DIFF
--- a/Source/ProductQuest/dot_envrc.tmpl
+++ b/Source/ProductQuest/dot_envrc.tmpl
@@ -2,3 +2,5 @@ source_up .envrc
 
 export AWS_SSO_CONFIG=${PWD}/.aws-sso/config
 export AWS_CONFIG_FILE=${PWD}/.aws/config
+
+export GITHUB_TOKEN={{ protonPass "pass://Personal/ProductQuest/GithubToken" | trim }}


### PR DESCRIPTION
Add GITHUB_TOKEN environment variable to ProductQuest .envrc, sourced
from ProtonPass.