### PR TITLE
chore(shiny): track supplier and supplier-invoice envrcs in chezmoi

### DIFF
--- a/Source/shiny/supplier-invoice-service/dot_envrc.tmpl
+++ b/Source/shiny/supplier-invoice-service/dot_envrc.tmpl
@@ -1,0 +1,7 @@
+source_up .envrc
+export PORT=4090
+export AUTH_URL=http://localhost:4080
+export SERVICE=$(basename "$PWD")
+export URL=http://localhost:${PORT}/query
+export POSTGRES_URL="postgres://postgres:postgres@unbound-control-plane.orb.local:5432/supplier_invoice?sslmode=disable"
+export LOG_LEVEL=info

--- a/Source/shiny/supplier-service/dot_envrc.tmpl
+++ b/Source/shiny/supplier-service/dot_envrc.tmpl
@@ -1,0 +1,6 @@
+source_up .envrc
+export PORT=4089
+export AUTH_URL=http://localhost:4080
+export SERVICE=$(basename "$PWD")
+export URL=http://localhost:${PORT}/query
+export POSTGRES_URL="postgres://postgres:postgres@unbound-control-plane.orb.local:5432/supplier?sslmode=disable"


### PR DESCRIPTION
## Summary
- Add `Source/shiny/supplier-service/dot_envrc.tmpl`
- Add `Source/shiny/supplier-invoice-service/dot_envrc.tmpl`

Both services had `.envrc` files deployed under `~/Source/shiny/` but were not tracked in the chezmoi source tree. Files contain no secrets, so no ProtonPass templating was needed. Templates match the deployed files exactly (verified with `chezmoi diff`).

Part of a pass to bring all shiny service envrcs under chezmoi. Follow-up will handle `banking-service` and `tax-service` which need ProtonPass entries for their secrets first.

## Test plan
- [x] `chezmoi diff` shows no drift against deployed files
- [x] Template structure matches sibling services (consistent `dot_envrc.tmpl` naming even without templating)