### PR TITLE
feat(shiny): track banking and tax envrcs with ProtonPass secrets

### DIFF
--- a/Source/shiny/banking-service/dot_envrc.tmpl
+++ b/Source/shiny/banking-service/dot_envrc.tmpl
@@ -1,0 +1,12 @@
+source_up .envrc
+export PORT=4092
+export AUTH_URL=http://localhost:4080
+export SERVICE=$(basename "$PWD")
+export URL=http://localhost:${PORT}/query
+export POSTGRES_URL="postgres://postgres:postgres@unbound-control-plane.orb.local:5432/banking?sslmode=disable"
+export BANKING_MASTER_KEY={{ protonPass "pass://Personal/Shiny/BankingMasterKey" | trim }}
+export SWEDBANK_CLIENT_ID={{ protonPass "pass://Personal/Shiny/SwedbankClientId" | trim }}
+export SWEDBANK_CLIENT_SECRET={{ protonPass "pass://Personal/Shiny/SwedbankClientSecret" | trim }}
+export TINK_CLIENT_ID={{ protonPass "pass://Personal/Shiny/TinkClientId" | trim }}
+export TINK_CLIENT_SECRET={{ protonPass "pass://Personal/Shiny/TinkClientSecret" | trim }}
+

--- a/Source/shiny/tax-service/dot_envrc.tmpl
+++ b/Source/shiny/tax-service/dot_envrc.tmpl
@@ -1,0 +1,12 @@
+source_up .envrc
+export PORT=4091
+export AUTH_URL=http://localhost:4080
+export SERVICE=$(basename "$PWD")
+export URL=http://localhost:${PORT}/query
+export POSTGRES_URL="postgres://postgres:postgres@unbound-control-plane.orb.local:5432/tax?sslmode=disable"
+export LOG_LEVEL=debug
+export SKV_OAUTH_CLIENT_ID={{ protonPass "pass://Personal/Shiny/SkvOauthClientId" | trim }}
+export SKV_OAUTH_CLIENT_SECRET={{ protonPass "pass://Personal/Shiny/SkvOauthClientSecret" | trim }}
+export SKV_API_CLIENT_ID={{ protonPass "pass://Personal/Shiny/SkvApiClientId" | trim }}
+export SKV_API_CLIENT_SECRET={{ protonPass "pass://Personal/Shiny/SkvApiClientSecret" | trim }}
+export SKV_MASTER_KEY={{ protonPass "pass://Personal/Shiny/SkvMasterKey" | trim }}


### PR DESCRIPTION
## Summary
Brings the last two untracked shiny service envrcs into chezmoi:
- `Source/shiny/banking-service/dot_envrc.tmpl`
- `Source/shiny/tax-service/dot_envrc.tmpl`

Secrets are pulled from the existing `pass://Personal/Shiny` ProtonPass item. Ten new fields were added there:

**Banking:** `BankingMasterKey`, `SwedbankClientId`, `SwedbankClientSecret`, `TinkClientId`, `TinkClientSecret`
**Tax:** `SkvOauthClientId`, `SkvOauthClientSecret`, `SkvApiClientId`, `SkvApiClientSecret`, `SkvMasterKey`

## Notes for reviewer
- All 10 fields are stored as `Text` because pass-cli's `item update` only creates Text fields. The 6 secret fields (`*MasterKey`, `*Secret`) should be flipped to `Hidden` in the ProtonPass UI for proper masking. Template retrieval works identically for both types.
- All shiny services are now tracked: `reporting-service` is the only remaining one without an `.envrc`, but it has no `.envrc` deployed either.

## Test plan
- [x] `chezmoi diff` shows zero drift against deployed `~/Source/shiny/banking-service/.envrc` and `~/Source/shiny/tax-service/.envrc`
- [x] Sample template resolution verified via `chezmoi execute-template`
- [ ] Flip 6 secret fields from Text to Hidden in ProtonPass web UI