### PR TITLE
feat(shiny): switch banking-service to OpenPayments provider

### DIFF
--- a/Source/shiny/banking-service/dot_envrc.tmpl
+++ b/Source/shiny/banking-service/dot_envrc.tmpl
@@ -5,8 +5,5 @@ export SERVICE=$(basename "$PWD")
 export URL=http://localhost:${PORT}/query
 export POSTGRES_URL="postgres://postgres:postgres@unbound-control-plane.orb.local:5432/banking?sslmode=disable"
 export BANKING_MASTER_KEY={{ protonPass "pass://Personal/Shiny/BankingMasterKey" | trim }}
-export SWEDBANK_CLIENT_ID={{ protonPass "pass://Personal/Shiny/SwedbankClientId" | trim }}
-export SWEDBANK_CLIENT_SECRET={{ protonPass "pass://Personal/Shiny/SwedbankClientSecret" | trim }}
-export TINK_CLIENT_ID={{ protonPass "pass://Personal/Shiny/TinkClientId" | trim }}
-export TINK_CLIENT_SECRET={{ protonPass "pass://Personal/Shiny/TinkClientSecret" | trim }}
-
+export OPENPAYMENTS_CLIENT_ID={{ protonPass "pass://Personal/Shiny/OpenPaymentsClientId" | trim }}
+export OPENPAYMENTS_CLIENT_SECRET={{ protonPass "pass://Personal/Shiny/OpenPaymentsClientSecret" | trim }}


### PR DESCRIPTION
## Summary

Replaces Swedbank and Tink client credentials with a single OpenPayments provider in `banking-service/.envrc`.

- Removed: `SWEDBANK_CLIENT_ID`, `SWEDBANK_CLIENT_SECRET`, `TINK_CLIENT_ID`, `TINK_CLIENT_SECRET`
- Added: `OPENPAYMENTS_CLIENT_ID`, `OPENPAYMENTS_CLIENT_SECRET`
- Source: `pass://Personal/Shiny/OpenPaymentsClientId` and `…ClientSecret`

## Test plan

- [ ] `pass-cli item view --vault-name Personal --item-title Shiny` shows `OpenPaymentsClientId` and `OpenPaymentsClientSecret` fields
- [ ] `chezmoi diff Source/shiny/banking-service/.envrc` renders without errors
- [ ] `chezmoi apply` deploys cleanly and `direnv allow` loads the new env vars
- [ ] Banking service starts against the new provider