### PR TITLE
feat(ssh): add fbg-01-ancr01 key templates

### DIFF
--- a/private_dot_ssh/fbg-01-ancr01.pub.tmpl
+++ b/private_dot_ssh/fbg-01-ancr01.pub.tmpl
@@ -1,0 +1,1 @@
+{{ protonPass "pass://Frostmoln shared/fbg-01-ancr01-ssh/Public key" | trim }}

--- a/private_dot_ssh/private_fbg-01-ancr01.tmpl
+++ b/private_dot_ssh/private_fbg-01-ancr01.tmpl
@@ -1,0 +1,1 @@
+{{ protonPass "pass://Frostmoln shared/fbg-01-ancr01-ssh/Private key" | trim }}


### PR DESCRIPTION
## Summary

Adds chezmoi templates for the `fbg-01-ancr01` SSH keypair, sourced from ProtonPass.

- `private_dot_ssh/fbg-01-ancr01.pub.tmpl` → `~/.ssh/fbg-01-ancr01.pub`
- `private_dot_ssh/private_fbg-01-ancr01.tmpl` → `~/.ssh/fbg-01-ancr01` (mode 0600 via `private_` prefix)
- Secrets: `pass://Frostmoln shared/fbg-01-ancr01-ssh/Public key` and `…/Private key`

## Test plan

- [ ] `pass-cli item view --vault-name "Frostmoln shared" --item-title fbg-01-ancr01-ssh` shows both fields
- [ ] `chezmoi diff ~/.ssh/fbg-01-ancr01 ~/.ssh/fbg-01-ancr01.pub` renders without errors
- [ ] `chezmoi apply` deploys both files with correct permissions (private key 0600)
- [ ] `ssh -i ~/.ssh/fbg-01-ancr01 <user>@fbg-01-ancr01` authenticates