### PR TITLE
feat(tmux): bind prefix B to send Ctrl-\ serial break

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -28,6 +28,9 @@ unbind %
 # Set reload key to r
 bind r source-file ~/.tmux.conf
 
+# Send Ctrl-\ (0x1C, SIGQUIT / serial break) — awkward to type on Swedish Mac layout
+bind B send-keys 'C-\'
+
 # Count sessions start at 1
 set -g base-index 1
 set-option -g renumber-windows on


### PR DESCRIPTION
Add `bind B send-keys 'C-\'` so that `Ctrl-Space B` injects the
0x1C control byte (SIGQUIT / serial break) into the focused pane.

Typing `Ctrl-\` directly is awkward on a Swedish Mac keyboard
because `\` requires Shift+Option+7 and macOS tends to swallow
the Option modifier before it reaches the pty. Routing the byte
through tmux's `send-keys` bypasses the keyboard layout entirely.