### PR TITLE
feat(ssh): add iDRAC SSH config from ProtonPass

### DIFF
--- a/private_dot_ssh/private_config.d/frostmoln-idrac.tmpl
+++ b/private_dot_ssh/private_config.d/frostmoln-idrac.tmpl
@@ -1,0 +1,1 @@
+{{ protonPass "pass://Frostmoln shared/iDRAC SSH config/config" | trim }}


### PR DESCRIPTION
Add a chezmoi template at `private_dot_ssh/private_config.d/frostmoln-idrac.tmpl`
that pulls the iDRAC SSH config snippet from the Frostmoln shared
ProtonPass vault and deploys it to `~/.ssh/config.d/frostmoln-idrac`.