### PR TITLE
feat(claude): auto-invoke caveman skill on session start

### DIFF
--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -134,7 +134,7 @@
     ],
     "deny": [],
     "ask": [],
-    "defaultMode": "default"
+    "defaultMode": "auto"
   },
   "hooks": {
     "PreToolUse": [
@@ -188,7 +188,21 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"Invoke the caveman skill in full mode now for this session.\"}}'"
+          }
+        ]
+      }
     ]
   },
-  "voiceEnabled": true
+  "skipAutoPermissionPrompt": true,
+  "voiceEnabled": true,
+  "teammateMode": "auto",
+  "remoteControlAtStartup": true,
+  "agentPushNotifEnabled": true
 }


### PR DESCRIPTION
## Summary

- Add a `SessionStart` hook to `~/.claude/settings.json` that injects a system-reminder telling Claude Code to invoke the `caveman` skill in full mode at the start of every session. The hook runs a `printf` command that emits `hookSpecificOutput.additionalContext` — equivalent to the user asking for caveman mode, but automatic.
- Port runtime-drifted settings from the deployed file back into the chezmoi source so `chezmoi apply` no longer clobbers them: `defaultMode: auto`, `skipAutoPermissionPrompt`, `teammateMode: auto`, `remoteControlAtStartup`, `agentPushNotifEnabled`.

## Test plan

- [ ] Start a new Claude Code session and confirm the assistant opens in caveman full mode without being asked
- [ ] Run `chezmoi diff ~/.claude/settings.json` on gwaihir and confirm no unexpected drift
- [ ] Verify existing PreToolUse / Stop / Notification hooks still fire (tmux notify, gitbutler guard, etc.)