### PR TITLE
feat(frostmoln): set up multi-kubeconfig env and add sops

### DIFF
--- a/Source/Frostmoln/dot_envrc.tmpl
+++ b/Source/Frostmoln/dot_envrc.tmpl
@@ -5,3 +5,4 @@ export GITEA_TOKEN={{ protonPass "pass://Personal/git.sm.internal/Token" | trim 
 export GOPRIVATE="git.sm.internal/*,go.frostmoln.internal/*"
 export GONOSUMCHECK="git.sm.internal/*,go.frostmoln.internal/*"
 export GOINSECURE="git.sm.internal,go.frostmoln.internal"
+export KUBECONFIG=$( IFS=:; set -- ${PWD}/.kube/kind*.yaml ${PWD}/.kube/*.yaml; echo "$*" )

--- a/dot_local/share/Brewfile.tmpl
+++ b/dot_local/share/Brewfile.tmpl
@@ -145,6 +145,7 @@ brew "python@3.11"
 brew "rbenv"
 brew "schpet/tap/linear"
 brew "socat"
+brew "sops"
 brew "ssh-copy-id", link: true
 brew "sshpass"
 brew "stategraph/stategraph/stategraph"


### PR DESCRIPTION
## Summary

- **`Source/Frostmoln/dot_envrc.tmpl`**: adds `export KUBECONFIG` that colon-joins `.kube/kind*.yaml` then `.kube/*.yaml`. kubectl merges configs in list order, so kind clusters take precedence on name collisions.
- **`Source/Frostmoln/dot_kube/create_kind-frostmoln.yaml`**: adds an (empty) placeholder where the real kind cluster spec will live.
- **`dot_local/share/Brewfile.tmpl`**: adds \`brew "sops"\` so Mozilla sops is available for editing encrypted YAML / JSON secrets used in the Frostmoln workflow.

## Test plan

- [ ] `cd Source/Frostmoln && direnv allow && echo \$KUBECONFIG` — should expand to a colon-separated list of the expected files
- [ ] `kubectl --context kind-frostmoln config get-contexts` — confirm merged contexts are reachable
- [ ] `bup` — picks up the new \`sops\` line and installs cleanly
- [ ] \`which sops && sops --version\` — confirm the binary is on PATH