### PR TITLE
docs(gitbutler): note that but push is silent on success

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -119,4 +119,5 @@ Use `but` CLI instead of git. Full reference: `~/.claude/gitbutler-reference.md`
    - `-c <branch>` to create+commit in one step (no `--only`)
    - `-p <cliId1>,<cliId2>` for partial commits
 6. `but pull` then `but push <branch>`
+   - `but push` is silent on success (no output) — only prints on errors. Verify with `git ls-remote --heads origin <branch>` if in doubt.
    - Conflicts: `but resolve <commit>`, fix, `but resolve finish`

--- a/private_dot_claude/gitbutler-reference.md
+++ b/private_dot_claude/gitbutler-reference.md
@@ -93,6 +93,8 @@
 | `but pr template` | Select PR description template from repo |
 | `but merge <branch>` | Merge a branch into local target branch |
 
+> **Note:** `but push` is silent on success — no stdout is produced when the push completes cleanly. Output only appears when there's an error (non-fast-forward, auth failure, network issue, etc.). To confirm a push landed, run `git ls-remote --heads origin <branch>` and compare the SHA to your local commit.
+
 ## Operation History
 
 | Command | Purpose |


### PR DESCRIPTION
## Summary

- **`private_dot_claude/CLAUDE.md`** (commit workflow step 6): inline one-liner noting that \`but push\` is silent on success; fall back to \`git ls-remote --heads origin <branch>\` if verification is needed.
- **`private_dot_claude/gitbutler-reference.md`** (after Server Interactions table): fuller blockquote with the same note plus the failure cases that *do* produce output (non-fast-forward, auth, network).

Context: caught this mid-session when a \`but push\` call returned zero output — chained with \`&&\` it read as "did nothing" rather than "pushed cleanly". Documenting the convention so future sessions don't retry or second-guess.

## Test plan

- [ ] \`chezmoi diff ~/.claude/CLAUDE.md ~/.claude/gitbutler-reference.md\` is empty after \`chezmoi apply\`
- [ ] Open \`~/.claude/gitbutler-reference.md\` and verify the Server Interactions markdown table still renders (note is positioned *after* the table, not between rows)