### PR TITLE
docs(gitbutler): update CLI reference for but 0.19.10

### DIFF
--- a/private_dot_claude/gitbutler-reference.md
+++ b/private_dot_claude/gitbutler-reference.md
@@ -1,5 +1,9 @@
 # GitButler CLI - Full Command Reference
 
+> Reference verified against `but 0.19.10`.
+>
+> Most mutation commands accept `--status-after` to also print workspace status after the command (in JSON mode, wraps `{"result": ..., "status": ...}`).
+
 ## Inspection
 
 | Command | Purpose |
@@ -29,10 +33,12 @@
 | `but stage <file-or-hunk> <branch>` | Stage a file or hunk to a branch (alternative to rub) |
 | `but commit --only -m "msg" <branch>` | Commit only assigned files to branch |
 | `but commit -c <name> -m "msg"` | Create new branch and commit (if name matches existing branch, uses that) |
-| `but commit -p <cliId> -m "msg" <branch>` | Commit specific files/hunks only |
+| `but commit -p <cliId>[,<cliId>...] -m "msg" <branch>` | Commit specific files/hunks (`-p` repeatable or comma-sep) |
 | `but commit -i -m "msg" <branch>` | AI-generated commit message (optional summary after `--ai=`) |
 | `but commit -n <branch>` | Bypass pre-commit hooks |
 | `but commit --message-file <file> <branch>` | Read commit message from file |
+| `but commit --diff <branch>` | Always show diff in editor (regardless of size) |
+| `but commit --no-diff <branch>` | Never show diff in editor |
 | `but commit empty --before <target>` | Insert blank placeholder commit before target |
 | `but commit empty --after <target>` | Insert blank placeholder commit after target |
 | `but mark <branch>` | Auto-stage new changes to this branch |
@@ -41,14 +47,18 @@
 | `but unmark` | Remove all marks |
 | `but apply <branch>` | Apply (enable) an unapplied branch |
 | `but unapply <branch>` | Unapply (stash) a branch from workspace |
+| `but unapply -f <branch>` | Force unapply without confirmation |
 | `but discard <cliId>` | Discard uncommitted changes for a file/hunk |
 | `but branch delete <branch>` | Delete a branch |
+| `but branch show <branch>` | Show commits ahead of base for a branch |
 
 ## Editing Commits
 
 | Command | Purpose |
 |---------|---------|
 | `but reword <commit-id> -m "msg"` | Edit a commit message |
+| `but reword <commit-id> -f` | Reformat existing message to 72-char wrap (no editor) |
+| `but reword <commit-id> --diff` / `--no-diff` | Force show / hide diff inside editor |
 | `but reword <branch-id> -m "name"` | Rename a branch |
 | `but absorb` | Amend uncommitted changes into appropriate existing commits |
 | `but absorb <cliId>` | Absorb a specific uncommitted file into its matching commit |
@@ -59,9 +69,13 @@
 | `but squash <branch>` | Squash all commits in branch into bottom-most |
 | `but squash <commit1> <commit2>` | Squash first commit into second |
 | `but squash <commit1>..<commit2>` | Squash commit range into last commit |
+| `but squash -d <commits...>` | Drop source commit messages, keep only target's |
+| `but squash -m "msg" <commits...>` | Provide a fresh message for the squashed commit |
+| `but squash -i <commits...>` / `-i="hint"` | AI-generated squash message (optional hint) |
 | `but move <commit> <target>` | Move commit before target (commit or branch) |
 | `but move <commit> <target> --after` | Move commit after target |
 | `but uncommit <commit>` | Uncommit changes back to unstaged area |
+| `but uncommit -d <commit>` | Discard committed changes entirely (no return to unassigned) |
 | `but pick <source> <target-branch>` | Cherry-pick from unapplied branch |
 
 ## Conflict Resolution
@@ -81,12 +95,16 @@
 | `but push` | Push all branches with unpushed commits (non-interactive) |
 | `but push -d <branch>` | Dry-run: show what would be pushed |
 | `but push -f <branch>` | Force push even if not fast-forward |
-| `but push -r <branch>` | Run pre-push hooks |
+| `but push -s <branch>` | Skip force-push protection checks |
+| `but push --no-hooks <branch>` (alias `--no-verify`) | Bypass pre-push hooks |
 | `but pull --check` | Check if branches can cleanly merge without updating |
-| `but pr new -m "title\n\nbody" <branch>` | Create PR with custom title and body (GitHub only) |
+| `but pr new -m "title\n\nbody" <branch>` | Create PR with title/body (NOTE: shell does not expand `\n` in quotes — use `-F` for multiline) |
 | `but pr new -F <file> <branch>` | Read PR title/body from file (first line = title, rest = body) |
 | `but pr new -d <branch>` | Create PR as draft |
 | `but pr new -t <branch>` | Create PR using default content from commits (required for GitLab) |
+| `but pr new -f <branch>` | Force push even if not fast-forward (default behavior) |
+| `but pr new -s <branch>` | Skip force-push protection checks |
+| `but pr new --no-hooks <branch>` (alias `--no-verify`) | Bypass pre-push hooks |
 | `but pr auto-merge <branch>` | Enable/disable auto-merge on a PR |
 | `but pr set-draft <branch>` | Set existing PR as draft |
 | `but pr set-ready <branch>` | Set existing PR as ready for review |
@@ -99,24 +117,39 @@
 
 | Command | Purpose |
 |---------|---------|
-| `but undo` | Undo the last operation |
-| `but oplog` | View operation history |
+| `but undo` | Undo the last operation (revert to previous snapshot) |
+| `but oplog` / `but oplog list` | View operation history (default: last 20 entries) |
+| `but oplog snapshot` | Create an on-demand snapshot (optional `-m "msg"`) |
+| `but oplog restore <oplog-sha>` | Restore workspace to a specific snapshot |
 
 ## Other
 
 | Command | Purpose |
 |---------|---------|
 | `but gui` / `but .` | Open the GitButler GUI for current project |
+| `but tui` | Open the interactive TUI |
 | `but setup` | Set up a GitButler project from a git repo |
 | `but setup --init` | Initialize a new git repo and set up GitButler |
 | `but teardown` | Exit GitButler mode, return to normal Git workflow |
-| `but stack <branch> <target>` | Move existing branch on top of another to stack them |
-| `but config` | View configuration overview (user, forge, target, metrics, ui) |
+| `but clean` | Remove empty branches (no local commits, no assigned changes) |
+| `but clean --dry-run` | Preview which empty branches would be removed |
+| `but clean --pull` | Pull latest from remote, then clean |
+| `but clean --include-upstream` | Also remove branches with only upstream-only commits |
+| `but move <branch> <target>` | Stack one branch on top of another (replaces old `but stack`) |
+| `but move <branch> zz` | Tear off (unstack) a branch |
+| `but config` | View configuration overview (user, forge, target, metrics, ui, ai) |
+| `but config user set name "Name"` / `email "x@y"` | Set user identity |
+| `but config forge` | View/manage forge configuration |
+| `but config target` | View/set target branch |
+| `but config metrics` | View/set metrics collection |
 | `but config ui set tui true` | Enable TUI mode for diff by default |
+| `but config ai` | View/configure AI provider settings |
 | `but alias add <name> <command>` | Create command shortcut |
 | `but alias remove <name>` | Remove a command shortcut |
 | `but alias list` | List all aliases |
-| `but skill install` | Install GitButler AI skill files for coding agents |
+| `but skill install` | Interactive: prompt for scope (repo/global) and format |
+| `but skill install --global` | Install skill files into home directory |
+| `but skill install --path <path>` | Install to a custom absolute or `~`-prefixed path |
 | `but skill check` | Check if installed skills are up to date |
 | `but update check` | Check for new CLI version |
 | `but update install` | Install or update the GitButler desktop app |


### PR DESCRIPTION
Refresh `private_dot_claude/gitbutler-reference.md` against `but --help` output for v0.19.10.

Highlights:
- Pin reference to 0.19.10; note global `--status-after`.
- Drop removed `but stack`; replace with `but move <branch> <target>` / `but move <branch> zz`.
- Fix wrong `but push -r` row; document real flags (`-s/--skip-force-push-protection`, `--no-hooks`/`--no-verify`).
- Add new `but tui`, `but clean` (+`--dry-run`/`--pull`/`--include-upstream`), `but branch show`.
- Add `oplog snapshot` + explicit `oplog restore <sha>`.
- Add `commit --diff`/`--no-diff`, `reword -f`/`--diff`/`--no-diff`, `squash -d`/`-m`/`-i`, `uncommit -d`, `unapply -f`.
- Add `config metrics`/`ai`, `config user set name|email`, `skill install --global`/`--path`.
- Add new `pr new` flags (`-f`/`-s`/`--no-hooks`) and footnote that the shell does not expand `\n` inside quoted `-m`.