### PR TITLE
feat(frostmoln): set vault env vars

### DIFF
--- a/Source/Frostmoln/dot_envrc.tmpl
+++ b/Source/Frostmoln/dot_envrc.tmpl
@@ -6,3 +6,5 @@ export GOPRIVATE="git.sm.internal/*,go.frostmoln.internal/*"
 export GONOSUMCHECK="git.sm.internal/*,go.frostmoln.internal/*"
 export GOINSECURE="git.sm.internal,go.frostmoln.internal"
 export KUBECONFIG=$( IFS=:; set -- ${PWD}/.kube/kind*.yaml ${PWD}/.kube/*.yaml; echo "$*" )
+export VAULT_ADDR=https://vault.frostmoln.internal:8200
+export VAULT_SKIP_VERIFY=true


### PR DESCRIPTION
Add two Vault client env vars to `Source/Frostmoln/dot_envrc.tmpl`:

- `VAULT_ADDR=https://vault.frostmoln.internal:8200`
- `VAULT_SKIP_VERIFY=true`

Scoped to the Frostmoln subtree via direnv.