### PR TITLE
fix(zsh): keep fpath shell-local to survive brew zsh upgrades

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -1,3 +1,10 @@
+# zsh ties $FPATH<->$fpath. If FPATH gets exported, child shells inherit it and it
+# survives `brew upgrade zsh`, leaving a dead Cellar/zsh/<old>/functions dir on fpath
+# that breaks autoload (compinit, is-at-least, add-zsh-hook, ...). Keep it shell-local
+# and pin the live, unversioned core functions dir so a bump can never strand us.
+typeset +x FPATH 2>/dev/null
+fpath=($HOMEBREW_PREFIX/share/zsh/functions $fpath)
+
 # Source Prezto.
 if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/init.zsh" ]]; then
   source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"


### PR DESCRIPTION
## What happened

`brew upgrade zsh` (5.9 → 5.9.1) deleted `…/Cellar/zsh/5.9/share/zsh/functions`. The environment carried an **exported** `FPATH` still pointing at that now-deleted versioned dir, inherited from a long-lived tmux server started before the upgrade. With the core function dir gone from `$fpath`, every `autoload` failed — `is-at-least`, `compinit`, `compdef`, `complete`, `bashcompinit`, `add-zsh-hook` — cascading errors in every new shell (and prezto falsely reporting "old shell detected").

## Fix

Add a guard at the top of `.zshrc`, before the prezto source (prezto's own `is-at-least` is a victim):

- `typeset +x FPATH` — un-export, so child shells recompute `fpath` per-version instead of inheriting a frozen path.
- Prepend `$HOMEBREW_PREFIX/share/zsh/functions` — an unversioned symlink that always tracks the current cellar, so a future bump can never strand autoload.

Self-healing: even a pane that inherits the stale `FPATH` resolves correctly on next shell start, so no `tmux kill-server` is needed going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)