### PR TITLE
chore(brewfile): add shellcheck

### DIFF
--- a/dot_local/share/Brewfile.tmpl
+++ b/dot_local/share/Brewfile.tmpl
@@ -146,6 +146,7 @@ brew "pyenv-virtualenv"
 brew "python@3.11"
 brew "rbenv"
 brew "schpet/tap/linear"
+brew "shellcheck"
 brew "socat"
 brew "sops"
 brew "ssh-copy-id", link: true


### PR DESCRIPTION
Add `shellcheck` static analyzer to the common (all-machine) Brewfile section.

Useful for linting the many `run_once_*.sh` and `executable_` shell scripts in this repo.