### PR TITLE
fix(zsh): stop direnv unloading spam during ssh tab completion

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -50,6 +50,10 @@ zstyle ':completion::complete:*' use-cache 1
 zstyle ':completion:*' list-colors "=(#b) #([0-9]#)*=36=31"
 
 eval "$(direnv hook zsh)"
+# zsh 5.9.1's _ssh_hosts cds inside completion subshells, which fires the
+# chpwd-registered direnv hook and spams "direnv: unloading". precmd alone
+# keeps the env current, so drop the chpwd registration.
+chpwd_functions=(${chpwd_functions:#_direnv_hook})
 
 autoload -Uz compinit && compinit -i
 


### PR DESCRIPTION
## Problem

Since the brew zsh upgrade to 5.9.1, every TAB completion of an ssh host printed multiple `direnv: unloading` lines when inside a direnv-managed directory.

## Root cause

zsh 5.9.1's `_ssh_hosts` expands `Include` lines from `~/.ssh/config` via `$(cd $HOME/.ssh; cat ...)`. The `cd` inside the completion subshell fires the chpwd-registered direnv hook with inherited `DIRENV_*` state — `~/.ssh` has no `.envrc`, so direnv prints "unloading" once per Include expansion (harmless noise; the parent shell env is never touched).

## Fix

Drop `_direnv_hook` from `chpwd_functions` after `direnv hook zsh`. The precmd registration alone keeps the environment current on every prompt (this was direnv's only hook mechanism for years).

Verified with a scripted interactive-zsh repro: 0 unloading messages after the fix, host completion and direnv loading still work.