### PR TITLE
fix(git): set push.default to simple to prevent stale-branch rewinds

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -114,7 +114,7 @@
   diffFilter = delta --color-only --dark
 
 [push]
-  default = matching
+  default = simple
   autoSetupRemote = true
   followTags = true
 


### PR DESCRIPTION
Global `~/.gitconfig` carried `push.default = matching`, the pre-Git-2.0 default.

`matching` pushes **every** local branch that has a same-named branch on the remote on a bare `git push` — so a stale local `main` riding along on a feature-branch push can rewind remote `main`.

`simple` (the Git 2.0+ default) pushes only the current branch to its upstream and refuses on an upstream-name mismatch. The existing `autoSetupRemote = true` still auto-creates upstreams for new branches, so there's no workflow regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)