### PR TITLE
feat(ambix): add auth0 terraform envrc

### DIFF
--- a/Source/Ambix/infrastructure/auth0/dot_envrc.tmpl
+++ b/Source/Ambix/infrastructure/auth0/dot_envrc.tmpl
@@ -1,0 +1,3 @@
+source_up .envrc
+export AUTH0_CLIENT_ID={{ protonPass "pass://Ambix shared/auth0/Terraform ClientId" | trim }}
+export AUTH0_CLIENT_SECRET={{ protonPass "pass://Ambix shared/auth0/Terraform ClientSecret" | trim }}


### PR DESCRIPTION
Adds `Source/Ambix/infrastructure/auth0/dot_envrc.tmpl`, exporting `AUTH0_CLIENT_ID` / `AUTH0_CLIENT_SECRET` for Terraform from ProtonPass (`Ambix shared/auth0`). Inherits the parent environment via `source_up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)