### PR TITLE
fix(brew): bypass Homebrew tap-trust gate that breaks non-interactive bundle

### DIFF
--- a/dot_functions
+++ b/dot_functions
@@ -56,6 +56,11 @@ ldeploy() {
 
 bup() {
   local result file
+  # Homebrew >=6 tap-trust gate is buggy on current HEAD (loses ~/.homebrew/trust.json
+  # mid-run), so `brew trust` does not persist. Opt out for this function's brew calls only.
+  # `local -x` exports it to child processes (brew) but auto-unsets when bup returns, so it
+  # never leaks into the interactive shell.
+  local -x HOMEBREW_NO_REQUIRE_TAP_TRUST=1
   file="${HOME}/.local/share/Brewfile"
 
   echo "Checking Brewfile"

--- a/run_once_000_install-packages-darwin.sh.tmpl
+++ b/run_once_000_install-packages-darwin.sh.tmpl
@@ -5,6 +5,16 @@
 
 type brew >/dev/null 2>&1 || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-brew bundle cleanup --force --file={{ joinPath .chezmoi.homeDir ".local" "share" "Brewfile" | quote }}
-brew bundle --file={{ joinPath .chezmoi.homeDir ".local" "share" "Brewfile" | quote }}
+BREWFILE={{ joinPath .chezmoi.homeDir ".local" "share" "Brewfile" | quote }}
+
+# Homebrew >=6 added a per-formula/cask "tap trust" gate that breaks non-interactive
+# `brew bundle` for third-party taps. On current Homebrew HEAD the gate is buggy: it loses
+# its own trust store (~/.homebrew/trust.json) during bundle runs, so explicit `brew trust`
+# does not persist. Opt out of the gate for this automated bundle of the curated Brewfile
+# only (scoped to this script's process; not exported into interactive shells via dot_exports).
+# Revisit once the trust feature stabilizes upstream.
+export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
+
+brew bundle cleanup --force --file="$BREWFILE"
+brew bundle --file="$BREWFILE"
 {{ end -}}


### PR DESCRIPTION
## Problem
Homebrew >=6 added a per-formula/cask **tap-trust** gate. On the current Homebrew HEAD build (6.0.2-149) the gate is buggy: it loses its own trust store (`~/.homebrew/trust.json`) during `brew bundle` runs, so `brew trust` never persists and `brew bundle` aborts with `Refusing to load formula ... from untrusted tap`. The suggested `brew trust --formula ...` fix is itself broken on this build, and bundle gates per-formula (not per-tap), so manual trusting just walks the wall.

## Fix (automation-only, smallest blast radius)
- `run_once_000_install-packages-darwin.sh.tmpl`: `export HOMEBREW_NO_REQUIRE_TAP_TRUST=1` (scoped to the script process; **not** added to `dot_exports`).
- `dot_functions` (`bup`): `local -x HOMEBREW_NO_REQUIRE_TAP_TRUST=1` — exported to the `brew` subprocesses but auto-unset when the function returns, so it never leaks into the interactive shell.

Interactive `brew install <untrusted-tap>/x` still enforces the supply-chain gate. Revisit once the trust feature stabilizes upstream (the env var is a documented transition escape hatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfMbRN4uAYfWkjbadtwnfQ