### PR TITLE
fix(tmux): load continuum after catppuccin so auto-save survives

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -129,8 +129,10 @@ set -s escape-time 0
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
-set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'catppuccin/tmux#v2.1.2'
+# continuum must load AFTER any plugin that sets status-right (catppuccin),
+# since it appends its auto-save hook there. Keep it last.
+set -g @plugin 'tmux-plugins/tmux-continuum'
 
 set -g @continuum-restore 'on'
 


### PR DESCRIPTION
## Problem
tmux session restore was loading a stale (~2 month old) layout. Auto-save
had silently stopped on Apr 22.

## Cause
tmux-continuum has no daemon — it appends its auto-save hook to
`status-right`, re-evaluated by the status bar. TPM sources plugins in
declaration order, and `catppuccin` was declared *after* `tmux-continuum`,
so catppuccin's `status-right` overwrote the hook. Auto-save died; restore
kept replaying the last snapshot that did save.

## Fix
Move `tmux-continuum` to be the last `@plugin` so its hook is appended on
top of catppuccin's status bar. One-line reorder, no new code. Verified
live: `status-right` now carries `continuum_save.sh` and a fresh snapshot
was written.